### PR TITLE
Handle intersection type when getting node properties

### DIFF
--- a/.changeset/lovely-hairs-give.md
+++ b/.changeset/lovely-hairs-give.md
@@ -1,0 +1,5 @@
+---
+'@eddeee888/gcg-typescript-resolver-files': patch
+---
+
+Handle intersection typeNode usually seen in GQL Interface types e.g. `type TypeA = TypeB & { something: string } & { somethingelse: string }`

--- a/packages/typescript-resolver-files/src/utils/getNodePropertyMap.ts
+++ b/packages/typescript-resolver-files/src/utils/getNodePropertyMap.ts
@@ -59,7 +59,7 @@ const collectTypeNodeProperties = (
       });
   } else if (Node.isIntersectionTypeNode(typeNode)) {
     typeNode.getTypeNodes().forEach((typeNode) => {
-      collectTypeNodeProperties(typeNode, result);
+      collectTypeNodeProperties(typeNode, result); // May contain duplicated properties from different typeNodes. Will be deduped in getNodePropertyMap.
     });
   }
 };


### PR DESCRIPTION
This will be used when we implement `Interface` handler because the generated type may look like this:

```
export type TypeA = {
  __typename: 'TypeA',
  id: string;
}
export type TypeB = TypeA & {   // This is Intersection Union type of ReferencedType and LiteralType
  __typename: 'TypeB',
  id: string;
  otherprop: string;
}
```