### PR TITLE
Fix typeDefsFileMode=modules on Windows when used with hooks (like afterAllFileWrite)

### DIFF
--- a/.changeset/wild-sheep-tell.md
+++ b/.changeset/wild-sheep-tell.md
@@ -1,0 +1,5 @@
+---
+'@eddeee888/gcg-typescript-resolver-files': patch
+---
+
+Fix typeDefsFileMode=modules not working well with codegen hooks (e.g. afterAllFileWrite) for Windows

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "@changesets/cli": "2.26.0",
-    "@eddeee888/nx-graphql-code-generator": "0.1.0",
+    "@eddeee888/nx-graphql-code-generator": "0.1.1",
     "@graphql-codegen/add": "4.0.0",
     "@graphql-codegen/cli": "3.3.0",
     "@graphql-codegen/plugin-helpers": "4.2.0",

--- a/packages/typescript-resolver-files-e2e/src/test-mappers-vs-schema-types/modules/user/profile.mappers.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-mappers-vs-schema-types/modules/user/profile.mappers.ts
@@ -7,9 +7,9 @@ export {
 } from './profileTypes';
 
 // import from fake node_modules
-export { CountryMapper } from '@graphql-code-generator-plugins/typescript-resolver-files-e2e-external/type-at-root';
+export { CountryMapper } from 'mock_node_modules/type-at-root';
 
 // import from node_modules and re-named
-import { Account } from '@graphql-code-generator-plugins/typescript-resolver-files-e2e-external/type-at-root';
+import { Account } from 'mock_node_modules/type-at-root';
 type AccountMapper = Account;
 export { AccountMapper };

--- a/packages/typescript-resolver-files-e2e/tsconfig.json
+++ b/packages/typescript-resolver-files-e2e/tsconfig.json
@@ -11,6 +11,11 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "paths": {
+      "mock_node_modules/*": [
+        "packages/typescript-resolver-files-e2e/mock_node_modules/*"
+      ]
+    }
   }
 }

--- a/packages/typescript-resolver-files/src/generateTypeDefsFiles/generateTypeDefsFiles.ts
+++ b/packages/typescript-resolver-files/src/generateTypeDefsFiles/generateTypeDefsFiles.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import { StandardFile } from '../generateResolverFiles';
 import type { ParseSourcesResult } from '../parseSources';
-import { isWhitelistedModule } from '../utils';
+import { cwd, isWhitelistedModule } from '../utils';
 import { TypeDefsFileMode } from '../validatePresetConfig';
 import { generateTypeDefsContent } from './generateTypeDefsContent';
 
@@ -49,9 +49,13 @@ export const generateTypeDefsFiles = ({
     }
 
     if (isWhitelisted && typeDefsFileMode === 'modules') {
+      // sourcePath.dir is absolute which does not work well to use as filenames for Windows
+      // example of cases where it does not work:
+      //   - when `prettier` is run in afterAllFileWrite hooks with absolute Windows path
+      const relativeSourcePathDir = path.posix.relative(cwd(), sourcePath.dir);
       appendSDLToFile({
         filesContent,
-        filePath: path.posix.join(sourcePath.dir, typeDefsFilePath),
+        filePath: path.posix.join(relativeSourcePathDir, typeDefsFilePath),
         rawSDL: source.rawSDL,
       });
       return;

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -17,12 +17,6 @@
     "paths": {
       "@eddeee888/gcg-typescript-resolver-files": [
         "packages/typescript-resolver-files/src/index.ts"
-      ],
-      "@graphql-code-generator-plugins/typescript-resolver-files-e2e": [
-        "packages/typescript-resolver-files/src/index.ts"
-      ],
-      "@graphql-code-generator-plugins/typescript-resolver-files-e2e-external/*": [
-        "packages/typescript-resolver-files-e2e/mock_node_modules/*"
       ]
     }
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1438,10 +1438,10 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@eddeee888/nx-graphql-code-generator@0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@eddeee888/nx-graphql-code-generator/-/nx-graphql-code-generator-0.1.0.tgz#61d30f6ea9fa24140f3adf5c7f8b90ec014505a0"
-  integrity sha512-PX4yBWcj6pDlPhs+3O3Fa1nqcpKRQH03/qyB/t4nrn4OL10Ommk5Y8u/1cXmJoWHrxGoaBAWZ0SMT5NkTms39A==
+"@eddeee888/nx-graphql-code-generator@0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@eddeee888/nx-graphql-code-generator/-/nx-graphql-code-generator-0.1.1.tgz#50473fc7175d4c4efff4e37b0da8763c0109d03b"
+  integrity sha512-k2VrCJSce0MxzYyfe4Y1zS17KsjnaYG3dOrUkAaSd37jCWSMMSxYKMFoGFe3d2AFZDgUSdkqhB0MSa2BEzK5QQ==
 
 "@eslint/eslintrc@^1.2.3":
   version "1.4.1"


### PR DESCRIPTION
Patch issue an issue where `typeDefsFileMode=modules` does not work for Windows when used with hooks like `afterAllFileWrite`

Fixes:
- Bump nx codegen plugin
- Fix mock node modules