### PR TITLE
[0.5] Set native ID scalar type

### DIFF
--- a/.changeset/smart-dolphins-wonder.md
+++ b/.changeset/smart-dolphins-wonder.md
@@ -1,0 +1,5 @@
+---
+'@eddeee888/gcg-typescript-resolver-files': patch
+---
+
+Change default scalar ID type from string string -> string | number

--- a/.changeset/smart-dolphins-wonder.md
+++ b/.changeset/smart-dolphins-wonder.md
@@ -2,4 +2,4 @@
 '@eddeee888/gcg-typescript-resolver-files': patch
 ---
 
-Change default scalar ID type from string string -> string | number
+Change native ID scalar's type from string -> string | number

--- a/packages/typescript-resolver-files-e2e/src/test-config-overrides/modules/types.gen.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-config-overrides/modules/types.gen.ts
@@ -20,7 +20,7 @@ export type RequireFields<T, K extends keyof T> = Omit<T, K> & {
 };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: string;
+  ID: string | number;
   String: string;
   Boolean: boolean;
   Int: number;

--- a/packages/typescript-resolver-files-e2e/src/test-config-ts/modules/types.generated.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-config-ts/modules/types.generated.ts
@@ -15,7 +15,7 @@ export type RequireFields<T, K extends keyof T> = Omit<T, K> & {
 };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: string;
+  ID: string | number;
   String: string;
   Boolean: boolean;
   Int: number;

--- a/packages/typescript-resolver-files-e2e/src/test-external-resolvers/modules/types.generated.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-external-resolvers/modules/types.generated.ts
@@ -19,7 +19,7 @@ export type RequireFields<T, K extends keyof T> = Omit<T, K> & {
 };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: string;
+  ID: string | number;
   String: string;
   Boolean: boolean;
   Int: number;

--- a/packages/typescript-resolver-files-e2e/src/test-mappers-vs-schema-types/modules/types.generated.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-mappers-vs-schema-types/modules/types.generated.ts
@@ -27,7 +27,7 @@ export type RequireFields<T, K extends keyof T> = Omit<T, K> & {
 };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: string;
+  ID: string | number;
   String: string;
   Boolean: boolean;
   Int: number;

--- a/packages/typescript-resolver-files-e2e/src/test-mappers-vs-schema-types/modules/user/resolvers/Account.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-mappers-vs-schema-types/modules/user/resolvers/Account.ts
@@ -1,8 +1,4 @@
 import type { AccountResolvers } from './../../types.generated';
 export const Account: AccountResolvers = {
   /* Implement Account resolver logic here */
-  id: ({ id }) => {
-    /* Account.id resolver is required because Account.id and AccountMapper.id are not compatible */
-    return id;
-  },
 };

--- a/packages/typescript-resolver-files-e2e/src/test-mappers-vs-schema-types/modules/user/resolvers/Profile.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-mappers-vs-schema-types/modules/user/resolvers/Profile.ts
@@ -1,10 +1,6 @@
 import type { ProfileResolvers } from './../../types.generated';
 export const Profile: ProfileResolvers = {
   /* Implement Profile resolver logic here */
-  id: ({ id }) => {
-    /* Profile.id resolver is required because Profile.id and ProfileMapper.id are not compatible */
-    return id;
-  },
   user: () => {
     /* Profile.user resolver is required because Profile.user exists but ProfileMapper.user does not */
   },

--- a/packages/typescript-resolver-files-e2e/src/test-mappers-vs-schema-types/modules/user/resolvers/ProfileMeta.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-mappers-vs-schema-types/modules/user/resolvers/ProfileMeta.ts
@@ -1,10 +1,6 @@
 import type { ProfileMetaResolvers } from './../../types.generated';
 export const ProfileMeta: ProfileMetaResolvers = {
   /* Implement ProfileMeta resolver logic here */
-  id: ({ id }) => {
-    /* ProfileMeta.id resolver is required because ProfileMeta.id and ProfileMetaMapper.id are not compatible */
-    return id;
-  },
   isCompleted: () => {
     /* ProfileMeta.isCompleted resolver is required because ProfileMeta.isCompleted exists but ProfileMetaMapper.isCompleted does not */
   },

--- a/packages/typescript-resolver-files-e2e/src/test-mappers-vs-schema-types/modules/user/resolvers/User.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-mappers-vs-schema-types/modules/user/resolvers/User.ts
@@ -10,8 +10,4 @@ export const User: UserResolvers = {
   fullName: () => {
     /* User.fullName resolver is required because User.fullName exists but UserMapper.fullName does not */
   },
-  id: ({ id }) => {
-    /* User.id resolver is required because User.id and UserMapper.id are not compatible */
-    return id;
-  },
 };

--- a/packages/typescript-resolver-files-e2e/src/test-mappers/modules/types.generated.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-mappers/modules/types.generated.ts
@@ -20,7 +20,7 @@ export type RequireFields<T, K extends keyof T> = Omit<T, K> & {
 };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: string;
+  ID: string | number;
   String: string;
   Boolean: boolean;
   Int: number;

--- a/packages/typescript-resolver-files-e2e/src/test-merged/graphql/resolvers/types.generated.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-merged/graphql/resolvers/types.generated.ts
@@ -22,7 +22,7 @@ export type RequireFields<T, K extends keyof T> = Omit<T, K> & {
 };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: string;
+  ID: string | number;
   String: string;
   Boolean: boolean;
   Int: number;

--- a/packages/typescript-resolver-files-e2e/src/test-modules-resolver-main-file-mode/modules/types.generated.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-modules-resolver-main-file-mode/modules/types.generated.ts
@@ -19,7 +19,7 @@ export type RequireFields<T, K extends keyof T> = Omit<T, K> & {
 };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: string;
+  ID: string | number;
   String: string;
   Boolean: boolean;
   Int: number;

--- a/packages/typescript-resolver-files-e2e/src/test-modules-typedefs-file-mode/modules/types.generated.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-modules-typedefs-file-mode/modules/types.generated.ts
@@ -19,7 +19,7 @@ export type RequireFields<T, K extends keyof T> = Omit<T, K> & {
 };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: string;
+  ID: string | number;
   String: string;
   Boolean: boolean;
   Int: number;

--- a/packages/typescript-resolver-files-e2e/src/test-modules/modules/types.generated.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-modules/modules/types.generated.ts
@@ -22,7 +22,7 @@ export type RequireFields<T, K extends keyof T> = Omit<T, K> & {
 };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: string;
+  ID: string | number;
   String: string;
   Boolean: boolean;
   Int: number;

--- a/packages/typescript-resolver-files-e2e/src/test-scalars-module/schema-overrides/types.generated.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-scalars-module/schema-overrides/types.generated.ts
@@ -21,7 +21,7 @@ export type RequireFields<T, K extends keyof T> = Omit<T, K> & {
 };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: string;
+  ID: string | number;
   String: string;
   Boolean: boolean;
   Int: number;

--- a/packages/typescript-resolver-files-e2e/src/test-scalars-module/schema/types.generated.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-scalars-module/schema/types.generated.ts
@@ -21,7 +21,7 @@ export type RequireFields<T, K extends keyof T> = Omit<T, K> & {
 };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: string;
+  ID: string | number;
   String: string;
   Boolean: boolean;
   Int: number;

--- a/packages/typescript-resolver-files-e2e/src/test-whitelisted/modules-typedefs-file-mode-mergedWhitelisted/types.generated.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-whitelisted/modules-typedefs-file-mode-mergedWhitelisted/types.generated.ts
@@ -19,7 +19,7 @@ export type RequireFields<T, K extends keyof T> = Omit<T, K> & {
 };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: string;
+  ID: string | number;
   String: string;
   Boolean: boolean;
   Int: number;

--- a/packages/typescript-resolver-files-e2e/src/test-whitelisted/modules/types.generated.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-whitelisted/modules/types.generated.ts
@@ -19,7 +19,7 @@ export type RequireFields<T, K extends keyof T> = Omit<T, K> & {
 };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: string;
+  ID: string | number;
   String: string;
   Boolean: boolean;
   Int: number;

--- a/packages/typescript-resolver-files/src/validateAndMergeParsedConfigs/validateAndMergeParsedConfigs.spec.ts
+++ b/packages/typescript-resolver-files/src/validateAndMergeParsedConfigs/validateAndMergeParsedConfigs.spec.ts
@@ -36,6 +36,7 @@ describe('validateAndMergeParsedConfigs', () => {
       },
       scalarTypes: {
         DateTime: 'string',
+        ID: 'string | number',
       },
       typeMappers: {
         User: './user/schema.mappers#UserMapper',

--- a/packages/typescript-resolver-files/src/validateAndMergeParsedConfigs/validateAndMergeParsedConfigs.ts
+++ b/packages/typescript-resolver-files/src/validateAndMergeParsedConfigs/validateAndMergeParsedConfigs.ts
@@ -2,6 +2,10 @@ import type { ParsedGraphQLSchemaMeta } from '../parseGraphQLSchema';
 import type { ParsedPresetConfig } from '../validatePresetConfig';
 import { fmt } from '../utils';
 
+const nativeScalarTypes = {
+  ID: 'string | number',
+};
+
 interface MergedConfig {
   userDefinedSchemaTypeMap: ParsedGraphQLSchemaMeta['userDefinedSchemaTypeMap'];
   externalResolvers: ParsedPresetConfig['externalResolvers'];
@@ -45,7 +49,10 @@ export const validateAndMergeParsedConfigs = ({
       ...defaultScalarExternalResolvers,
       ...externalResolvers,
     },
-    scalarTypes: defaultScalarTypesMap,
+    scalarTypes: {
+      ...defaultScalarTypesMap,
+      ...nativeScalarTypes,
+    },
     typeMappers: defaultTypeMappers,
   };
 };


### PR DESCRIPTION
Related: https://github.com/dotansimha/graphql-code-generator/issues/2588

ID type should be `string | number` because native ID scalar resolver can handle `string | number`.
This also baselines e2e which removes extraneous `id` resolvers