### PR TITLE
Make e2e tests better

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,4 +106,4 @@ jobs:
         run: yarn install --prefer-offline
 
       - name: e2e
-        run: yarn nx e2e typescript-resolver-files-e2e -c clean-run
+        run: yarn nx e2e typescript-resolver-files-e2e

--- a/packages/typescript-resolver-files-e2e/README.md
+++ b/packages/typescript-resolver-files-e2e/README.md
@@ -5,3 +5,19 @@ This library was generated with [Nx](https://nx.dev).
 ## Running lint
 
 Run `nx lint typescript-resolver-files` to execute the lint via [ESLint](https://eslint.org/).
+
+## Testing
+
+```shell
+nx e2e typescript-resolver-files-e2e # Cleans all the generated files, generates files for each test, then assert.
+
+nx e2e-run typescript-resolver-files-e2e -c clean-run # Cleans up all generated files, generates files for each test.
+
+nx e2e-run typescript-resolver-files-e2e # Generates files for each test.
+
+nx graphql-codegen typescript-resolver-files-e2e -c <test-name> # Generates files for a test.
+
+nx e2e-cleanup typescript-resolver-files-e2e # Cleans up all generated files.
+
+nx e2e-cleanup typescript-resolver-files-e2e -c <test-name> # Cleans up all generated files for a test.
+```

--- a/packages/typescript-resolver-files-e2e/README.md
+++ b/packages/typescript-resolver-files-e2e/README.md
@@ -9,7 +9,7 @@ Run `nx lint typescript-resolver-files` to execute the lint via [ESLint](https:/
 ## Testing
 
 ```shell
-nx e2e typescript-resolver-files-e2e # Cleans all the generated files, generates files for each test, then assert.
+nx e2e typescript-resolver-files-e2e # Cleans up all generated files, generates files for each test, then assert.
 
 nx e2e-run typescript-resolver-files-e2e -c clean-run # Cleans up all generated files, generates files for each test.
 

--- a/packages/typescript-resolver-files-e2e/project.json
+++ b/packages/typescript-resolver-files-e2e/project.json
@@ -8,31 +8,94 @@
       "executor": "nx:run-commands",
       "options": {
         "commands": [
-          "nx e2e-run typescript-resolver-files-e2e",
+          "nx e2e-run typescript-resolver-files-e2e -c clean-run",
           "bash packages/typescript-resolver-files-e2e/bin/assert-e2e.sh"
         ],
         "parallel": false
-      },
-      "configurations": {
-        "clean-run": {
-          "commands": [
-            "nx e2e-run typescript-resolver-files-e2e -c clean-run",
-            "bash packages/typescript-resolver-files-e2e/bin/assert-e2e.sh"
-          ],
-          "parallel": false
-        }
       }
     },
     "e2e-cleanup": {
       "executor": "nx:run-commands",
       "options": {
         "commands": [
-          "rimraf -g 'packages/typescript-resolver-files-e2e/src/test-*/**/resolvers/'",
-          "rimraf -g 'packages/typescript-resolver-files-e2e/src/test-*/**/rslvrs/'",
+          "rimraf -g 'packages/typescript-resolver-files-e2e/src/**/resolvers/'",
+          "rimraf -g 'packages/typescript-resolver-files-e2e/src/**/rslvrs/'",
           "rimraf -g 'packages/typescript-resolver-files-e2e/src/**/*.generated.*'",
           "rimraf -g 'packages/typescript-resolver-files-e2e/src/**/*.gen.*'"
         ],
         "parallel": false
+      },
+      "configurations": {
+        "test-merged": {
+          "commands": [
+            "rimraf -g 'packages/typescript-resolver-files-e2e/src/test-merged/**/resolvers/'",
+            "rimraf -g 'packages/typescript-resolver-files-e2e/src/test-merged/**/*.generated.*'"
+          ],
+          "parallel": false
+        },
+        "test-modules": {
+          "commands": [
+            "rimraf -g 'packages/typescript-resolver-files-e2e/src/test-modules/**/resolvers/'",
+            "rimraf -g 'packages/typescript-resolver-files-e2e/src/test-modules/**/*.generated.*'"
+          ],
+          "parallel": false
+        },
+        "test-whitelisted": {
+          "commands": [
+            "rimraf -g 'packages/typescript-resolver-files-e2e/src/test-whitelisted/**/resolvers/'",
+            "rimraf -g 'packages/typescript-resolver-files-e2e/src/test-whitelisted/**/*.generated.*'"
+          ],
+          "parallel": false
+        },
+        "test-external-resolvers": {
+          "commands": [
+            "rimraf -g 'packages/typescript-resolver-files-e2e/src/test-external-resolvers/**/resolvers/'",
+            "rimraf -g 'packages/typescript-resolver-files-e2e/src/test-external-resolvers/**/*.generated.*'"
+          ],
+          "parallel": false
+        },
+        "test-config-overrides": {
+          "commands": [
+            "rimraf -g 'packages/typescript-resolver-files-e2e/src/test-config-overrides/**/rslvrs/'",
+            "rimraf -g 'packages/typescript-resolver-files-e2e/src/test-config-overrides/**/*.gen.*'"
+          ],
+          "parallel": false
+        },
+        "test-mappers": {
+          "commands": [
+            "rimraf -g 'packages/typescript-resolver-files-e2e/src/test-mappers/**/resolvers/'",
+            "rimraf -g 'packages/typescript-resolver-files-e2e/src/test-mappers/**/*.generated.*'"
+          ],
+          "parallel": false
+        },
+        "test-mappers-vs-schema-types": {
+          "commands": [
+            "rimraf -g 'packages/typescript-resolver-files-e2e/src/test-mappers-vs-schema-types/**/resolvers/'",
+            "rimraf -g 'packages/typescript-resolver-files-e2e/src/test-mappers-vs-schema-types/**/*.generated.*'"
+          ],
+          "parallel": false
+        },
+        "test-config-ts": {
+          "commands": [
+            "rimraf -g 'packages/typescript-resolver-files-e2e/src/test-config-ts/**/resolvers/'",
+            "rimraf -g 'packages/typescript-resolver-files-e2e/src/test-config-ts/**/*.generated.*'"
+          ],
+          "parallel": false
+        },
+        "test-modules-typedefs-file-mode": {
+          "commands": [
+            "rimraf -g 'packages/typescript-resolver-files-e2e/src/test-modules-typedefs-file-mode/**/resolvers/'",
+            "rimraf -g 'packages/typescript-resolver-files-e2e/src/test-modules-typedefs-file-mode/**/*.generated.*'"
+          ],
+          "parallel": false
+        },
+        "test-modules-resolver-main-file-mode": {
+          "commands": [
+            "rimraf -g 'packages/typescript-resolver-files-e2e/src/test-modules-resolver-main-file-mode/**/resolvers/'",
+            "rimraf -g 'packages/typescript-resolver-files-e2e/src/test-modules-resolver-main-file-mode/**/*.generated.*'"
+          ],
+          "parallel": false
+        }
       }
     },
     "e2e-run": {

--- a/packages/typescript-resolver-files/DEVELOPMENT.md
+++ b/packages/typescript-resolver-files/DEVELOPMENT.md
@@ -45,7 +45,7 @@ nx graphql-codegen typescript-resolver-files-e2e -c <test-name> --verbose
 nx e2e-run typescript-resolver-files-e2e -c clean-run
 
 # Run tests and assert. This is run in CI/CD.
-nx e2e typescript-resolver-files-e2e -c clean-run
+nx e2e typescript-resolver-files-e2e
 ```
 
 ## TODOs

--- a/tools/generators/typescript-resolver-files-add-e2e-test/index.ts
+++ b/tools/generators/typescript-resolver-files-add-e2e-test/index.ts
@@ -53,24 +53,40 @@ const addFiles = (tree: Tree, options: NormalizedSchema) => {
 };
 
 const updateProjectConfig = (tree: Tree, options: NormalizedSchema): void => {
-  const commands: string[] =
+  const e2eRunCommands: string[] =
     options.projectConfig.targets?.['e2e-run']?.options?.['commands'];
-  if (!commands) {
-    throw new Error('Unable to find e2e-run commands in project.json.');
+  if (!e2eRunCommands) {
+    throw new Error('Unable to find `e2e-run` commands in project.json.');
   }
+
   const graphQLCodegenConfig =
     options.projectConfig.targets?.['graphql-codegen']?.configurations;
   if (!graphQLCodegenConfig) {
     throw new Error(
-      'Unable to find graphql-codegen configurations in project.json.'
+      'Unable to find `graphql-codegen` configurations in project.json.'
     );
   }
 
-  commands.push(
+  const e2eCleanupConfig =
+    options.projectConfig.targets?.['e2e-cleanup']?.configurations;
+  if (!e2eCleanupConfig) {
+    throw new Error(
+      'Unable to find `e2e-cleanup` configurations in project.json.'
+    );
+  }
+
+  e2eRunCommands.push(
     `nx graphql-codegen typescript-resolver-files-e2e -c ${options.testFullName} --verbose`
   );
   graphQLCodegenConfig[options.testFullName] = {
     configFile: `packages/typescript-resolver-files-e2e/src/${options.testFullName}/codegen.ts`,
+  };
+  e2eCleanupConfig[options.testFullName] = {
+    commands: [
+      `rimraf -g 'packages/typescript-resolver-files-e2e/src/${options.testFullName}/**/resolvers/'`,
+      `rimraf -g 'packages/typescript-resolver-files-e2e/src/${options.testFullName}/**/*.generated.*'`,
+    ],
+    parallel: false,
   };
 
   updateProjectConfiguration(tree, options.projectName, options.projectConfig);


### PR DESCRIPTION
- `e2e` target now must cleanup, therefore can only have 1 config.
- Make `e2e-cleanup` able to target individual tests
- Update e2e README with common commands
- Update workspace e2e generator to generate `e2e-cleanup` correctly in the future