### PR TITLE
Add Interface handler

### DIFF
--- a/.changeset/quick-ants-mate.md
+++ b/.changeset/quick-ants-mate.md
@@ -1,0 +1,5 @@
+---
+'@eddeee888/gcg-typescript-resolver-files': minor
+---
+
+Add missing Interface file generation

--- a/packages/typescript-resolver-files-e2e/src/test-config-overrides/modules/base/rslvrs/Error.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-config-overrides/modules/base/rslvrs/Error.ts
@@ -1,0 +1,4 @@
+import type { ErrorResolvers } from './../../types.gen';
+export const Error: ErrorResolvers = {
+  /* Implement Error interface logic here */
+};

--- a/packages/typescript-resolver-files-e2e/src/test-config-overrides/modules/resolvers.gen.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-config-overrides/modules/resolvers.gen.ts
@@ -1,5 +1,6 @@
 /* This file was automatically generated. DO NOT UPDATE MANUALLY. */
 import type { Resolvers } from './types.gen';
+import { Error } from './base/rslvrs/Error';
 import { topicCreate as Mutation_topicCreate } from './topic/rslvrs/Mutation/topicCreate';
 import { topicEdit as Mutation_topicEdit } from './topic/rslvrs/Mutation/topicEdit';
 import { PaginationResult } from './base/rslvrs/PaginationResult';
@@ -38,6 +39,7 @@ export const resolvers: Resolvers = {
     topicEdit: Mutation_topicEdit,
   },
   Subscription: { profileChanges: Subscription_profileChanges },
+  Error: Error,
   PaginationResult: PaginationResult,
   Profile: Profile,
   SomeOtherScalars: SomeOtherScalars,

--- a/packages/typescript-resolver-files-e2e/src/test-config-overrides/modules/types.gen.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-config-overrides/modules/types.gen.ts
@@ -15,6 +15,15 @@ export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
   [SubKey in K]: Maybe<T[SubKey]>;
 };
+export type MakeEmpty<
+  T extends { [key: string]: unknown },
+  K extends keyof T
+> = { [_ in K]?: never };
+export type Incremental<T> =
+  | T
+  | {
+      [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never;
+    };
 export type RequireFields<T, K extends keyof T> = Omit<T, K> & {
   [P in K]-?: NonNullable<T[P]>;
 };
@@ -62,8 +71,8 @@ export type MutationTopicEditArgs = {
 };
 
 export type PaginationInput = {
-  page?: InputMaybe<Scalars['Int']['output']>;
-  recordsPerPage?: InputMaybe<Scalars['Int']['output']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  recordsPerPage?: InputMaybe<Scalars['Int']['input']>;
 };
 
 export type PaginationResult = {
@@ -126,8 +135,8 @@ export type TopicByIdResult = {
 };
 
 export type TopicCreateInput = {
-  name: Scalars['String']['output'];
-  url?: InputMaybe<Scalars['String']['output']>;
+  name: Scalars['String']['input'];
+  url?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type TopicCreatePayload = StandardError | TopicCreateResult;
@@ -138,9 +147,9 @@ export type TopicCreateResult = {
 };
 
 export type TopicEditInput = {
-  id: Scalars['ID']['output'];
-  name: Scalars['String']['output'];
-  url?: InputMaybe<Scalars['String']['output']>;
+  id: Scalars['ID']['input'];
+  name: Scalars['String']['input'];
+  url?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type TopicEditPayload = StandardError | TopicEditResult;
@@ -151,7 +160,7 @@ export type TopicEditResult = {
 };
 
 export type TopicsCreatedByUserInput = {
-  userId: Scalars['ID']['output'];
+  userId: Scalars['ID']['input'];
 };
 
 export type TopicsCreatedByUserPayload =

--- a/packages/typescript-resolver-files-e2e/src/test-config-ts/modules/types.generated.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-config-ts/modules/types.generated.ts
@@ -10,6 +10,15 @@ export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
   [SubKey in K]: Maybe<T[SubKey]>;
 };
+export type MakeEmpty<
+  T extends { [key: string]: unknown },
+  K extends keyof T
+> = { [_ in K]?: never };
+export type Incremental<T> =
+  | T
+  | {
+      [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never;
+    };
 export type RequireFields<T, K extends keyof T> = Omit<T, K> & {
   [P in K]-?: NonNullable<T[P]>;
 };

--- a/packages/typescript-resolver-files-e2e/src/test-esm-import/schema/base/resolvers/Error.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-esm-import/schema/base/resolvers/Error.ts
@@ -1,0 +1,4 @@
+import type { ErrorResolvers } from './../../types.generated.js';
+export const Error: ErrorResolvers = {
+  /* Implement Error interface logic here */
+};

--- a/packages/typescript-resolver-files-e2e/src/test-esm-import/schema/resolvers.generated.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-esm-import/schema/resolvers.generated.ts
@@ -1,5 +1,6 @@
 /* This file was automatically generated. DO NOT UPDATE MANUALLY. */
 import type { Resolvers } from './types.generated.js';
+import { Error } from './base/resolvers/Error.js';
 import { topicCreate as Mutation_topicCreate } from './topic/resolvers/Mutation/topicCreate.js';
 import { topicEdit as Mutation_topicEdit } from './topic/resolvers/Mutation/topicEdit.js';
 import { PaginationResult } from './base/resolvers/PaginationResult.js';
@@ -36,6 +37,7 @@ export const resolvers: Resolvers = {
     topicEdit: Mutation_topicEdit,
   },
   Subscription: { profileChanges: Subscription_profileChanges },
+  Error: Error,
   PaginationResult: PaginationResult,
   PayloadError: PayloadError,
   Profile: Profile,

--- a/packages/typescript-resolver-files-e2e/src/test-esm-import/schema/topic/resolvers/TopicByIdPayload.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-esm-import/schema/topic/resolvers/TopicByIdPayload.ts
@@ -1,4 +1,4 @@
 import type { TopicByIdPayloadResolvers } from './../../types.generated.js';
 export const TopicByIdPayload: TopicByIdPayloadResolvers = {
-  __resolveType: (parent) => parent.__typename,
+  /* Implement TopicByIdPayload union logic here */
 };

--- a/packages/typescript-resolver-files-e2e/src/test-esm-import/schema/topic/resolvers/TopicCreatePayload.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-esm-import/schema/topic/resolvers/TopicCreatePayload.ts
@@ -1,4 +1,4 @@
 import type { TopicCreatePayloadResolvers } from './../../types.generated.js';
 export const TopicCreatePayload: TopicCreatePayloadResolvers = {
-  __resolveType: (parent) => parent.__typename,
+  /* Implement TopicCreatePayload union logic here */
 };

--- a/packages/typescript-resolver-files-e2e/src/test-esm-import/schema/topic/resolvers/TopicEditPayload.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-esm-import/schema/topic/resolvers/TopicEditPayload.ts
@@ -1,4 +1,4 @@
 import type { TopicEditPayloadResolvers } from './../../types.generated.js';
 export const TopicEditPayload: TopicEditPayloadResolvers = {
-  __resolveType: (parent) => parent.__typename,
+  /* Implement TopicEditPayload union logic here */
 };

--- a/packages/typescript-resolver-files-e2e/src/test-esm-import/schema/topic/resolvers/TopicsCreatedByUserPayload.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-esm-import/schema/topic/resolvers/TopicsCreatedByUserPayload.ts
@@ -1,4 +1,4 @@
 import type { TopicsCreatedByUserPayloadResolvers } from './../../types.generated.js';
 export const TopicsCreatedByUserPayload: TopicsCreatedByUserPayloadResolvers = {
-  __resolveType: (parent) => parent.__typename,
+  /* Implement TopicsCreatedByUserPayload union logic here */
 };

--- a/packages/typescript-resolver-files-e2e/src/test-esm-import/schema/types.generated.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-esm-import/schema/types.generated.ts
@@ -15,19 +15,28 @@ export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
   [SubKey in K]: Maybe<T[SubKey]>;
 };
+export type MakeEmpty<
+  T extends { [key: string]: unknown },
+  K extends keyof T
+> = { [_ in K]?: never };
+export type Incremental<T> =
+  | T
+  | {
+      [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never;
+    };
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 export type RequireFields<T, K extends keyof T> = Omit<T, K> & {
   [P in K]-?: NonNullable<T[P]>;
 };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: string;
-  String: string;
-  Boolean: boolean;
-  Int: number;
-  Float: number;
-  DateTime: Date | string;
-  SomeRandomScalar: any;
+  ID: { input: string; output: string | number };
+  String: { input: string; output: string };
+  Boolean: { input: boolean; output: boolean };
+  Int: { input: number; output: number };
+  Float: { input: number; output: number };
+  DateTime: { input: Date | string; output: Date | string };
+  SomeRandomScalar: { input: any; output: any };
 };
 
 export type Error = {
@@ -41,7 +50,7 @@ export type ErrorType =
   | 'UNEXPECTED_ERROR';
 
 export type Mutation = {
-  __typename: 'Mutation';
+  __typename?: 'Mutation';
   topicCreate: TopicCreatePayload;
   topicEdit: TopicEditPayload;
 };
@@ -55,30 +64,30 @@ export type MutationTopicEditArgs = {
 };
 
 export type PaginationInput = {
-  page?: InputMaybe<Scalars['Int']>;
-  recordsPerPage?: InputMaybe<Scalars['Int']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  recordsPerPage?: InputMaybe<Scalars['Int']['input']>;
 };
 
 export type PaginationResult = {
-  __typename: 'PaginationResult';
-  currentPage: Scalars['Int'];
-  recordsPerPage: Scalars['Int'];
-  totalPageCount: Scalars['Int'];
+  __typename?: 'PaginationResult';
+  currentPage: Scalars['Int']['output'];
+  recordsPerPage: Scalars['Int']['output'];
+  totalPageCount: Scalars['Int']['output'];
 };
 
 export type PayloadError = Error & {
-  __typename: 'PayloadError';
+  __typename?: 'PayloadError';
   error: ErrorType;
 };
 
 export type Profile = {
-  __typename: 'Profile';
-  id: Scalars['ID'];
+  __typename?: 'Profile';
+  id: Scalars['ID']['output'];
   user: User;
 };
 
 export type Query = {
-  __typename: 'Query';
+  __typename?: 'Query';
   me: UserPayload;
   topicById: TopicByIdPayload;
   topicsCreatedByUser: TopicsCreatedByUserPayload;
@@ -86,7 +95,7 @@ export type Query = {
 };
 
 export type QueryTopicByIdArgs = {
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
 };
 
 export type QueryTopicsCreatedByUserArgs = {
@@ -94,57 +103,57 @@ export type QueryTopicsCreatedByUserArgs = {
 };
 
 export type QueryUserByAccountNameArgs = {
-  accountName: Scalars['String'];
+  accountName: Scalars['String']['input'];
 };
 
 export type Subscription = {
-  __typename: 'Subscription';
+  __typename?: 'Subscription';
   profileChanges: Profile;
 };
 
 export type Topic = {
-  __typename: 'Topic';
-  createdAt: Scalars['DateTime'];
+  __typename?: 'Topic';
+  createdAt: Scalars['DateTime']['output'];
   creator: User;
-  id: Scalars['ID'];
-  name: Scalars['String'];
-  url?: Maybe<Scalars['String']>;
+  id: Scalars['ID']['output'];
+  name: Scalars['String']['output'];
+  url?: Maybe<Scalars['String']['output']>;
 };
 
 export type TopicByIdPayload = PayloadError | TopicByIdResult;
 
 export type TopicByIdResult = {
-  __typename: 'TopicByIdResult';
+  __typename?: 'TopicByIdResult';
   result?: Maybe<Topic>;
 };
 
 export type TopicCreateInput = {
-  name: Scalars['String'];
-  url?: InputMaybe<Scalars['String']>;
+  name: Scalars['String']['input'];
+  url?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type TopicCreatePayload = PayloadError | TopicCreateResult;
 
 export type TopicCreateResult = {
-  __typename: 'TopicCreateResult';
+  __typename?: 'TopicCreateResult';
   result: Topic;
 };
 
 export type TopicEditInput = {
-  id: Scalars['ID'];
-  name: Scalars['String'];
-  url?: InputMaybe<Scalars['String']>;
+  id: Scalars['ID']['input'];
+  name: Scalars['String']['input'];
+  url?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type TopicEditPayload = PayloadError | TopicEditResult;
 
 export type TopicEditResult = {
-  __typename: 'TopicEditResult';
+  __typename?: 'TopicEditResult';
   result: Topic;
 };
 
 export type TopicsCreatedByUserInput = {
-  userId: Scalars['ID'];
+  userId: Scalars['ID']['input'];
 };
 
 export type TopicsCreatedByUserPayload =
@@ -152,26 +161,26 @@ export type TopicsCreatedByUserPayload =
   | TopicsCreatedByUserResult;
 
 export type TopicsCreatedByUserResult = {
-  __typename: 'TopicsCreatedByUserResult';
+  __typename?: 'TopicsCreatedByUserResult';
   result: Array<Topic>;
 };
 
 export type User = {
-  __typename: 'User';
-  accountGitHub?: Maybe<Scalars['String']>;
-  accountLinkedIn?: Maybe<Scalars['String']>;
-  accountName: Scalars['String'];
-  accountTwitter?: Maybe<Scalars['String']>;
-  accountWebsite?: Maybe<Scalars['String']>;
-  avatar?: Maybe<Scalars['String']>;
-  id: Scalars['ID'];
-  name?: Maybe<Scalars['String']>;
+  __typename?: 'User';
+  accountGitHub?: Maybe<Scalars['String']['output']>;
+  accountLinkedIn?: Maybe<Scalars['String']['output']>;
+  accountName: Scalars['String']['output'];
+  accountTwitter?: Maybe<Scalars['String']['output']>;
+  accountWebsite?: Maybe<Scalars['String']['output']>;
+  avatar?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  name?: Maybe<Scalars['String']['output']>;
 };
 
 export type UserPayload = PayloadError | UserResult;
 
 export type UserResult = {
-  __typename: 'UserResult';
+  __typename?: 'UserResult';
   result?: Maybe<User>;
 };
 
@@ -281,70 +290,56 @@ export type DirectiveResolverFn<
 ) => TResult | Promise<TResult>;
 
 /** Mapping of union types */
-export type ResolversUnionTypes = {
+export type ResolversUnionTypes<RefType extends Record<string, unknown>> = {
   TopicByIdPayload:
-    | PayloadError
+    | (PayloadError & { __typename: 'PayloadError' })
     | (Omit<TopicByIdResult, 'result'> & {
-        result?: Maybe<ResolversTypes['Topic']>;
-      });
+        result?: Maybe<RefType['Topic']>;
+      } & { __typename: 'TopicByIdResult' });
   TopicCreatePayload:
-    | PayloadError
-    | (Omit<TopicCreateResult, 'result'> & { result: ResolversTypes['Topic'] });
-  TopicEditPayload:
-    | PayloadError
-    | (Omit<TopicEditResult, 'result'> & { result: ResolversTypes['Topic'] });
-  TopicsCreatedByUserPayload:
-    | PayloadError
-    | (Omit<TopicsCreatedByUserResult, 'result'> & {
-        result: Array<ResolversTypes['Topic']>;
+    | (PayloadError & { __typename: 'PayloadError' })
+    | (Omit<TopicCreateResult, 'result'> & { result: RefType['Topic'] } & {
+        __typename: 'TopicCreateResult';
       });
-  UserPayload: PayloadError | UserResult;
+  TopicEditPayload:
+    | (PayloadError & { __typename: 'PayloadError' })
+    | (Omit<TopicEditResult, 'result'> & { result: RefType['Topic'] } & {
+        __typename: 'TopicEditResult';
+      });
+  TopicsCreatedByUserPayload:
+    | (PayloadError & { __typename: 'PayloadError' })
+    | (Omit<TopicsCreatedByUserResult, 'result'> & {
+        result: Array<RefType['Topic']>;
+      } & { __typename: 'TopicsCreatedByUserResult' });
+  UserPayload:
+    | (PayloadError & { __typename: 'PayloadError' })
+    | (UserResult & { __typename: 'UserResult' });
 };
 
-/** Mapping of union parent types */
-export type ResolversUnionParentTypes = {
-  TopicByIdPayload:
-    | PayloadError
-    | (Omit<TopicByIdResult, 'result'> & {
-        result?: Maybe<ResolversParentTypes['Topic']>;
-      });
-  TopicCreatePayload:
-    | PayloadError
-    | (Omit<TopicCreateResult, 'result'> & {
-        result: ResolversParentTypes['Topic'];
-      });
-  TopicEditPayload:
-    | PayloadError
-    | (Omit<TopicEditResult, 'result'> & {
-        result: ResolversParentTypes['Topic'];
-      });
-  TopicsCreatedByUserPayload:
-    | PayloadError
-    | (Omit<TopicsCreatedByUserResult, 'result'> & {
-        result: Array<ResolversParentTypes['Topic']>;
-      });
-  UserPayload: PayloadError | UserResult;
+/** Mapping of interface types */
+export type ResolversInterfaceTypes<RefType extends Record<string, unknown>> = {
+  Error: PayloadError & { __typename: 'PayloadError' };
 };
 
 /** Mapping between all available schema types and the resolvers types */
 export type ResolversTypes = {
-  DateTime: ResolverTypeWrapper<Scalars['DateTime']>;
-  Error: ResolversTypes['PayloadError'];
+  DateTime: ResolverTypeWrapper<Scalars['DateTime']['output']>;
+  Error: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['Error']>;
   ErrorType: ErrorType;
   Mutation: ResolverTypeWrapper<{}>;
   PaginationInput: PaginationInput;
-  Int: ResolverTypeWrapper<Scalars['Int']>;
+  Int: ResolverTypeWrapper<Scalars['Int']['output']>;
   PaginationResult: ResolverTypeWrapper<PaginationResult>;
   PayloadError: ResolverTypeWrapper<PayloadError>;
   Profile: ResolverTypeWrapper<Profile>;
-  ID: ResolverTypeWrapper<Scalars['ID']>;
+  ID: ResolverTypeWrapper<Scalars['ID']['output']>;
   Query: ResolverTypeWrapper<{}>;
-  String: ResolverTypeWrapper<Scalars['String']>;
-  SomeRandomScalar: ResolverTypeWrapper<Scalars['SomeRandomScalar']>;
+  String: ResolverTypeWrapper<Scalars['String']['output']>;
+  SomeRandomScalar: ResolverTypeWrapper<Scalars['SomeRandomScalar']['output']>;
   Subscription: ResolverTypeWrapper<{}>;
   Topic: ResolverTypeWrapper<TopicMapper>;
   TopicByIdPayload: ResolverTypeWrapper<
-    ResolversUnionTypes['TopicByIdPayload']
+    ResolversUnionTypes<ResolversTypes>['TopicByIdPayload']
   >;
   TopicByIdResult: ResolverTypeWrapper<
     Omit<TopicByIdResult, 'result'> & {
@@ -353,21 +348,21 @@ export type ResolversTypes = {
   >;
   TopicCreateInput: TopicCreateInput;
   TopicCreatePayload: ResolverTypeWrapper<
-    ResolversUnionTypes['TopicCreatePayload']
+    ResolversUnionTypes<ResolversTypes>['TopicCreatePayload']
   >;
   TopicCreateResult: ResolverTypeWrapper<
     Omit<TopicCreateResult, 'result'> & { result: ResolversTypes['Topic'] }
   >;
   TopicEditInput: TopicEditInput;
   TopicEditPayload: ResolverTypeWrapper<
-    ResolversUnionTypes['TopicEditPayload']
+    ResolversUnionTypes<ResolversTypes>['TopicEditPayload']
   >;
   TopicEditResult: ResolverTypeWrapper<
     Omit<TopicEditResult, 'result'> & { result: ResolversTypes['Topic'] }
   >;
   TopicsCreatedByUserInput: TopicsCreatedByUserInput;
   TopicsCreatedByUserPayload: ResolverTypeWrapper<
-    ResolversUnionTypes['TopicsCreatedByUserPayload']
+    ResolversUnionTypes<ResolversTypes>['TopicsCreatedByUserPayload']
   >;
   TopicsCreatedByUserResult: ResolverTypeWrapper<
     Omit<TopicsCreatedByUserResult, 'result'> & {
@@ -375,50 +370,52 @@ export type ResolversTypes = {
     }
   >;
   User: ResolverTypeWrapper<User>;
-  UserPayload: ResolverTypeWrapper<ResolversUnionTypes['UserPayload']>;
+  UserPayload: ResolverTypeWrapper<
+    ResolversUnionTypes<ResolversTypes>['UserPayload']
+  >;
   UserResult: ResolverTypeWrapper<UserResult>;
-  Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
+  Boolean: ResolverTypeWrapper<Scalars['Boolean']['output']>;
 };
 
 /** Mapping between all available schema types and the resolvers parents */
 export type ResolversParentTypes = {
-  DateTime: Scalars['DateTime'];
-  Error: ResolversParentTypes['PayloadError'];
+  DateTime: Scalars['DateTime']['output'];
+  Error: ResolversInterfaceTypes<ResolversParentTypes>['Error'];
   Mutation: {};
   PaginationInput: PaginationInput;
-  Int: Scalars['Int'];
+  Int: Scalars['Int']['output'];
   PaginationResult: PaginationResult;
   PayloadError: PayloadError;
   Profile: Profile;
-  ID: Scalars['ID'];
+  ID: Scalars['ID']['output'];
   Query: {};
-  String: Scalars['String'];
-  SomeRandomScalar: Scalars['SomeRandomScalar'];
+  String: Scalars['String']['output'];
+  SomeRandomScalar: Scalars['SomeRandomScalar']['output'];
   Subscription: {};
   Topic: TopicMapper;
-  TopicByIdPayload: ResolversUnionParentTypes['TopicByIdPayload'];
+  TopicByIdPayload: ResolversUnionTypes<ResolversParentTypes>['TopicByIdPayload'];
   TopicByIdResult: Omit<TopicByIdResult, 'result'> & {
     result?: Maybe<ResolversParentTypes['Topic']>;
   };
   TopicCreateInput: TopicCreateInput;
-  TopicCreatePayload: ResolversUnionParentTypes['TopicCreatePayload'];
+  TopicCreatePayload: ResolversUnionTypes<ResolversParentTypes>['TopicCreatePayload'];
   TopicCreateResult: Omit<TopicCreateResult, 'result'> & {
     result: ResolversParentTypes['Topic'];
   };
   TopicEditInput: TopicEditInput;
-  TopicEditPayload: ResolversUnionParentTypes['TopicEditPayload'];
+  TopicEditPayload: ResolversUnionTypes<ResolversParentTypes>['TopicEditPayload'];
   TopicEditResult: Omit<TopicEditResult, 'result'> & {
     result: ResolversParentTypes['Topic'];
   };
   TopicsCreatedByUserInput: TopicsCreatedByUserInput;
-  TopicsCreatedByUserPayload: ResolversUnionParentTypes['TopicsCreatedByUserPayload'];
+  TopicsCreatedByUserPayload: ResolversUnionTypes<ResolversParentTypes>['TopicsCreatedByUserPayload'];
   TopicsCreatedByUserResult: Omit<TopicsCreatedByUserResult, 'result'> & {
     result: Array<ResolversParentTypes['Topic']>;
   };
   User: User;
-  UserPayload: ResolversUnionParentTypes['UserPayload'];
+  UserPayload: ResolversUnionTypes<ResolversParentTypes>['UserPayload'];
   UserResult: UserResult;
-  Boolean: Scalars['Boolean'];
+  Boolean: Scalars['Boolean']['output'];
 };
 
 export interface DateTimeScalarConfig
@@ -430,7 +427,7 @@ export type ErrorResolvers<
   ContextType = any,
   ParentType extends ResolversParentTypes['Error'] = ResolversParentTypes['Error']
 > = {
-  __resolveType: TypeResolveFn<'PayloadError', ParentType, ContextType>;
+  __resolveType?: TypeResolveFn<'PayloadError', ParentType, ContextType>;
   error?: Resolver<ResolversTypes['ErrorType'], ParentType, ContextType>;
 };
 
@@ -537,7 +534,7 @@ export type TopicByIdPayloadResolvers<
   ContextType = any,
   ParentType extends ResolversParentTypes['TopicByIdPayload'] = ResolversParentTypes['TopicByIdPayload']
 > = {
-  __resolveType: TypeResolveFn<
+  __resolveType?: TypeResolveFn<
     'PayloadError' | 'TopicByIdResult',
     ParentType,
     ContextType
@@ -556,7 +553,7 @@ export type TopicCreatePayloadResolvers<
   ContextType = any,
   ParentType extends ResolversParentTypes['TopicCreatePayload'] = ResolversParentTypes['TopicCreatePayload']
 > = {
-  __resolveType: TypeResolveFn<
+  __resolveType?: TypeResolveFn<
     'PayloadError' | 'TopicCreateResult',
     ParentType,
     ContextType
@@ -575,7 +572,7 @@ export type TopicEditPayloadResolvers<
   ContextType = any,
   ParentType extends ResolversParentTypes['TopicEditPayload'] = ResolversParentTypes['TopicEditPayload']
 > = {
-  __resolveType: TypeResolveFn<
+  __resolveType?: TypeResolveFn<
     'PayloadError' | 'TopicEditResult',
     ParentType,
     ContextType
@@ -594,7 +591,7 @@ export type TopicsCreatedByUserPayloadResolvers<
   ContextType = any,
   ParentType extends ResolversParentTypes['TopicsCreatedByUserPayload'] = ResolversParentTypes['TopicsCreatedByUserPayload']
 > = {
-  __resolveType: TypeResolveFn<
+  __resolveType?: TypeResolveFn<
     'PayloadError' | 'TopicsCreatedByUserResult',
     ParentType,
     ContextType
@@ -644,7 +641,7 @@ export type UserPayloadResolvers<
   ContextType = any,
   ParentType extends ResolversParentTypes['UserPayload'] = ResolversParentTypes['UserPayload']
 > = {
-  __resolveType: TypeResolveFn<
+  __resolveType?: TypeResolveFn<
     'PayloadError' | 'UserResult',
     ParentType,
     ContextType

--- a/packages/typescript-resolver-files-e2e/src/test-esm-import/schema/user/resolvers/UserPayload.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-esm-import/schema/user/resolvers/UserPayload.ts
@@ -1,4 +1,4 @@
 import type { UserPayloadResolvers } from './../../types.generated.js';
 export const UserPayload: UserPayloadResolvers = {
-  __resolveType: (parent) => parent.__typename,
+  /* Implement UserPayload union logic here */
 };

--- a/packages/typescript-resolver-files-e2e/src/test-external-resolvers/modules/base/resolvers/Error.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-external-resolvers/modules/base/resolvers/Error.ts
@@ -1,0 +1,4 @@
+import type { ErrorResolvers } from './../../types.generated';
+export const Error: ErrorResolvers = {
+  /* Implement Error interface logic here */
+};

--- a/packages/typescript-resolver-files-e2e/src/test-external-resolvers/modules/resolvers.generated.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-external-resolvers/modules/resolvers.generated.ts
@@ -1,5 +1,6 @@
 /* This file was automatically generated. DO NOT UPDATE MANUALLY. */
 import type { Resolvers } from './types.generated';
+import { Error } from './base/resolvers/Error';
 import { topicCreate as Mutation_topicCreate } from './topic/resolvers/Mutation/topicCreate';
 import { topicEdit as Mutation_topicEdit } from './topic/resolvers/Mutation/topicEdit';
 import { PaginationResult } from './base/resolvers/PaginationResult';
@@ -46,6 +47,7 @@ export const resolvers: Resolvers = {
     topicEdit: Mutation_topicEdit,
   },
   Subscription: { profileChanges: Subscription_profileChanges },
+  Error: Error,
   PaginationResult: PaginationResult,
   Profile: Profile,
   StandardError: StandardError,

--- a/packages/typescript-resolver-files-e2e/src/test-external-resolvers/modules/types.generated.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-external-resolvers/modules/types.generated.ts
@@ -14,6 +14,15 @@ export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
   [SubKey in K]: Maybe<T[SubKey]>;
 };
+export type MakeEmpty<
+  T extends { [key: string]: unknown },
+  K extends keyof T
+> = { [_ in K]?: never };
+export type Incremental<T> =
+  | T
+  | {
+      [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never;
+    };
 export type RequireFields<T, K extends keyof T> = Omit<T, K> & {
   [P in K]-?: NonNullable<T[P]>;
 };
@@ -60,8 +69,8 @@ export type MutationTopicEditArgs = {
 };
 
 export type PaginationInput = {
-  page?: InputMaybe<Scalars['Int']['output']>;
-  recordsPerPage?: InputMaybe<Scalars['Int']['output']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  recordsPerPage?: InputMaybe<Scalars['Int']['input']>;
 };
 
 export type PaginationResult = {
@@ -124,8 +133,8 @@ export type TopicByIdResult = {
 };
 
 export type TopicCreateInput = {
-  name: Scalars['String']['output'];
-  url?: InputMaybe<Scalars['String']['output']>;
+  name: Scalars['String']['input'];
+  url?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type TopicCreatePayload = StandardError | TopicCreateResult;
@@ -136,9 +145,9 @@ export type TopicCreateResult = {
 };
 
 export type TopicEditInput = {
-  id: Scalars['ID']['output'];
-  name: Scalars['String']['output'];
-  url?: InputMaybe<Scalars['String']['output']>;
+  id: Scalars['ID']['input'];
+  name: Scalars['String']['input'];
+  url?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type TopicEditPayload = StandardError | TopicEditResult;
@@ -149,7 +158,7 @@ export type TopicEditResult = {
 };
 
 export type TopicsCreatedByUserInput = {
-  userId: Scalars['ID']['output'];
+  userId: Scalars['ID']['input'];
 };
 
 export type TopicsCreatedByUserPayload =

--- a/packages/typescript-resolver-files-e2e/src/test-mappers-vs-schema-types/modules/types.generated.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-mappers-vs-schema-types/modules/types.generated.ts
@@ -21,6 +21,15 @@ export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
   [SubKey in K]: Maybe<T[SubKey]>;
 };
+export type MakeEmpty<
+  T extends { [key: string]: unknown },
+  K extends keyof T
+> = { [_ in K]?: never };
+export type Incremental<T> =
+  | T
+  | {
+      [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never;
+    };
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 export type RequireFields<T, K extends keyof T> = Omit<T, K> & {
   [P in K]-?: NonNullable<T[P]>;
@@ -122,8 +131,8 @@ export type TopicByIdResult = {
 };
 
 export type TopicCreateInput = {
-  name: Scalars['String']['output'];
-  url?: InputMaybe<Scalars['String']['output']>;
+  name: Scalars['String']['input'];
+  url?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type TopicCreatePayload = Error | TopicCreateResult;
@@ -134,9 +143,9 @@ export type TopicCreateResult = {
 };
 
 export type TopicEditInput = {
-  id: Scalars['ID']['output'];
-  name: Scalars['String']['output'];
-  url?: InputMaybe<Scalars['String']['output']>;
+  id: Scalars['ID']['input'];
+  name: Scalars['String']['input'];
+  url?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type TopicEditPayload = Error | TopicEditResult;
@@ -147,7 +156,7 @@ export type TopicEditResult = {
 };
 
 export type TopicsCreatedByUserInput = {
-  userId: Scalars['ID']['output'];
+  userId: Scalars['ID']['input'];
 };
 
 export type TopicsCreatedByUserPayload = Error | TopicsCreatedByUserResult;

--- a/packages/typescript-resolver-files-e2e/src/test-mappers/modules/base/resolvers/Error.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-mappers/modules/base/resolvers/Error.ts
@@ -1,0 +1,4 @@
+import type { ErrorResolvers } from './../../types.generated';
+export const Error: ErrorResolvers = {
+  /* Implement Error interface logic here */
+};

--- a/packages/typescript-resolver-files-e2e/src/test-mappers/modules/resolvers.generated.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-mappers/modules/resolvers.generated.ts
@@ -1,5 +1,6 @@
 /* This file was automatically generated. DO NOT UPDATE MANUALLY. */
 import type { Resolvers } from './types.generated';
+import { Error } from './base/resolvers/Error';
 import { topicCreate as Mutation_topicCreate } from './topic/resolvers/Mutation/topicCreate';
 import { topicEdit as Mutation_topicEdit } from './topic/resolvers/Mutation/topicEdit';
 import { PaginationResult } from './base/resolvers/PaginationResult';
@@ -35,6 +36,7 @@ export const resolvers: Resolvers = {
     topicEdit: Mutation_topicEdit,
   },
   Subscription: { profileChanges: Subscription_profileChanges },
+  Error: Error,
   PaginationResult: PaginationResult,
   Profile: Profile,
   StandardError: StandardError,

--- a/packages/typescript-resolver-files-e2e/src/test-mappers/modules/types.generated.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-mappers/modules/types.generated.ts
@@ -15,6 +15,15 @@ export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
   [SubKey in K]: Maybe<T[SubKey]>;
 };
+export type MakeEmpty<
+  T extends { [key: string]: unknown },
+  K extends keyof T
+> = { [_ in K]?: never };
+export type Incremental<T> =
+  | T
+  | {
+      [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never;
+    };
 export type RequireFields<T, K extends keyof T> = Omit<T, K> & {
   [P in K]-?: NonNullable<T[P]>;
 };
@@ -53,8 +62,8 @@ export type MutationTopicEditArgs = {
 };
 
 export type PaginationInput = {
-  page?: InputMaybe<Scalars['Int']['output']>;
-  recordsPerPage?: InputMaybe<Scalars['Int']['output']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  recordsPerPage?: InputMaybe<Scalars['Int']['input']>;
 };
 
 export type PaginationResult = {
@@ -117,8 +126,8 @@ export type TopicByIdResult = {
 };
 
 export type TopicCreateInput = {
-  name: Scalars['String']['output'];
-  url?: InputMaybe<Scalars['String']['output']>;
+  name: Scalars['String']['input'];
+  url?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type TopicCreatePayload = StandardError | TopicCreateResult;
@@ -129,9 +138,9 @@ export type TopicCreateResult = {
 };
 
 export type TopicEditInput = {
-  id: Scalars['ID']['output'];
-  name: Scalars['String']['output'];
-  url?: InputMaybe<Scalars['String']['output']>;
+  id: Scalars['ID']['input'];
+  name: Scalars['String']['input'];
+  url?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type TopicEditPayload = StandardError | TopicEditResult;
@@ -142,7 +151,7 @@ export type TopicEditResult = {
 };
 
 export type TopicsCreatedByUserInput = {
-  userId: Scalars['ID']['output'];
+  userId: Scalars['ID']['input'];
 };
 
 export type TopicsCreatedByUserPayload =

--- a/packages/typescript-resolver-files-e2e/src/test-merged/graphql/resolvers/Error.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-merged/graphql/resolvers/Error.ts
@@ -1,0 +1,4 @@
+import type { ErrorResolvers } from './types.generated';
+export const Error: ErrorResolvers = {
+  /* Implement Error interface logic here */
+};

--- a/packages/typescript-resolver-files-e2e/src/test-merged/graphql/resolvers/index.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-merged/graphql/resolvers/index.ts
@@ -1,5 +1,6 @@
 /* This file was automatically generated. DO NOT UPDATE MANUALLY. */
 import type { Resolvers } from './types.generated';
+import { Error } from './Error';
 import { topicCreate as Mutation_topicCreate } from './Mutation/topicCreate';
 import { topicEdit as Mutation_topicEdit } from './Mutation/topicEdit';
 import { PaginationResult } from './PaginationResult';
@@ -33,6 +34,7 @@ export const resolvers: Resolvers = {
     topicEdit: Mutation_topicEdit,
   },
 
+  Error: Error,
   PaginationResult: PaginationResult,
   StandardError: StandardError,
   Topic: Topic,

--- a/packages/typescript-resolver-files-e2e/src/test-merged/graphql/resolvers/types.generated.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-merged/graphql/resolvers/types.generated.ts
@@ -16,6 +16,15 @@ export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
   [SubKey in K]: Maybe<T[SubKey]>;
 };
+export type MakeEmpty<
+  T extends { [key: string]: unknown },
+  K extends keyof T
+> = { [_ in K]?: never };
+export type Incremental<T> =
+  | T
+  | {
+      [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never;
+    };
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 export type RequireFields<T, K extends keyof T> = Omit<T, K> & {
   [P in K]-?: NonNullable<T[P]>;
@@ -55,8 +64,8 @@ export type MutationTopicEditArgs = {
 };
 
 export type PaginationInput = {
-  page?: InputMaybe<Scalars['Int']['output']>;
-  recordsPerPage?: InputMaybe<Scalars['Int']['output']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  recordsPerPage?: InputMaybe<Scalars['Int']['input']>;
 };
 
 export type PaginationResult = {
@@ -108,8 +117,8 @@ export type TopicByIdResult = {
 };
 
 export type TopicCreateInput = {
-  name: Scalars['String']['output'];
-  url?: InputMaybe<Scalars['String']['output']>;
+  name: Scalars['String']['input'];
+  url?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type TopicCreatePayload = StandardError | TopicCreateResult;
@@ -120,9 +129,9 @@ export type TopicCreateResult = {
 };
 
 export type TopicEditInput = {
-  id: Scalars['ID']['output'];
-  name: Scalars['String']['output'];
-  url?: InputMaybe<Scalars['String']['output']>;
+  id: Scalars['ID']['input'];
+  name: Scalars['String']['input'];
+  url?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type TopicEditPayload = StandardError | TopicEditResult;
@@ -133,7 +142,7 @@ export type TopicEditResult = {
 };
 
 export type TopicsCreatedByUserInput = {
-  userId: Scalars['ID']['output'];
+  userId: Scalars['ID']['input'];
 };
 
 export type TopicsCreatedByUserPayload =

--- a/packages/typescript-resolver-files-e2e/src/test-modules-resolver-main-file-mode/modules/base/resolvers.generated.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-modules-resolver-main-file-mode/modules/base/resolvers.generated.ts
@@ -1,9 +1,11 @@
 /* This file was automatically generated. DO NOT UPDATE MANUALLY. */
 import type { Resolvers } from './../types.generated';
+import { Error } from './resolvers/Error';
 import { PaginationResult } from './resolvers/PaginationResult';
 import { StandardError } from './resolvers/StandardError';
 import { DateTimeResolver } from 'graphql-scalars';
 export const resolvers: Resolvers = {
+  Error: Error,
   PaginationResult: PaginationResult,
   StandardError: StandardError,
   DateTime: DateTimeResolver,

--- a/packages/typescript-resolver-files-e2e/src/test-modules-resolver-main-file-mode/modules/base/resolvers/Error.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-modules-resolver-main-file-mode/modules/base/resolvers/Error.ts
@@ -1,0 +1,4 @@
+import type { ErrorResolvers } from './../../types.generated';
+export const Error: ErrorResolvers = {
+  /* Implement Error interface logic here */
+};

--- a/packages/typescript-resolver-files-e2e/src/test-modules-resolver-main-file-mode/modules/types.generated.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-modules-resolver-main-file-mode/modules/types.generated.ts
@@ -14,6 +14,15 @@ export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
   [SubKey in K]: Maybe<T[SubKey]>;
 };
+export type MakeEmpty<
+  T extends { [key: string]: unknown },
+  K extends keyof T
+> = { [_ in K]?: never };
+export type Incremental<T> =
+  | T
+  | {
+      [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never;
+    };
 export type RequireFields<T, K extends keyof T> = Omit<T, K> & {
   [P in K]-?: NonNullable<T[P]>;
 };
@@ -52,8 +61,8 @@ export type MutationTopicEditArgs = {
 };
 
 export type PaginationInput = {
-  page?: InputMaybe<Scalars['Int']['output']>;
-  recordsPerPage?: InputMaybe<Scalars['Int']['output']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  recordsPerPage?: InputMaybe<Scalars['Int']['input']>;
 };
 
 export type PaginationResult = {
@@ -116,8 +125,8 @@ export type TopicByIdResult = {
 };
 
 export type TopicCreateInput = {
-  name: Scalars['String']['output'];
-  url?: InputMaybe<Scalars['String']['output']>;
+  name: Scalars['String']['input'];
+  url?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type TopicCreatePayload = StandardError | TopicCreateResult;
@@ -128,9 +137,9 @@ export type TopicCreateResult = {
 };
 
 export type TopicEditInput = {
-  id: Scalars['ID']['output'];
-  name: Scalars['String']['output'];
-  url?: InputMaybe<Scalars['String']['output']>;
+  id: Scalars['ID']['input'];
+  name: Scalars['String']['input'];
+  url?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type TopicEditPayload = StandardError | TopicEditResult;
@@ -141,7 +150,7 @@ export type TopicEditResult = {
 };
 
 export type TopicsCreatedByUserInput = {
-  userId: Scalars['ID']['output'];
+  userId: Scalars['ID']['input'];
 };
 
 export type TopicsCreatedByUserPayload =

--- a/packages/typescript-resolver-files-e2e/src/test-modules-typedefs-file-mode/modules/base/resolvers/Error.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-modules-typedefs-file-mode/modules/base/resolvers/Error.ts
@@ -1,0 +1,4 @@
+import type { ErrorResolvers } from './../../types.generated';
+export const Error: ErrorResolvers = {
+  /* Implement Error interface logic here */
+};

--- a/packages/typescript-resolver-files-e2e/src/test-modules-typedefs-file-mode/modules/resolvers.generated.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-modules-typedefs-file-mode/modules/resolvers.generated.ts
@@ -1,5 +1,6 @@
 /* This file was automatically generated. DO NOT UPDATE MANUALLY. */
 import type { Resolvers } from './types.generated';
+import { Error } from './base/resolvers/Error';
 import { topicCreate as Mutation_topicCreate } from './topic/resolvers/Mutation/topicCreate';
 import { topicEdit as Mutation_topicEdit } from './topic/resolvers/Mutation/topicEdit';
 import { PaginationResult } from './base/resolvers/PaginationResult';
@@ -35,6 +36,7 @@ export const resolvers: Resolvers = {
     topicEdit: Mutation_topicEdit,
   },
   Subscription: { profileChanges: Subscription_profileChanges },
+  Error: Error,
   PaginationResult: PaginationResult,
   Profile: Profile,
   StandardError: StandardError,

--- a/packages/typescript-resolver-files-e2e/src/test-modules-typedefs-file-mode/modules/types.generated.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-modules-typedefs-file-mode/modules/types.generated.ts
@@ -14,6 +14,15 @@ export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
   [SubKey in K]: Maybe<T[SubKey]>;
 };
+export type MakeEmpty<
+  T extends { [key: string]: unknown },
+  K extends keyof T
+> = { [_ in K]?: never };
+export type Incremental<T> =
+  | T
+  | {
+      [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never;
+    };
 export type RequireFields<T, K extends keyof T> = Omit<T, K> & {
   [P in K]-?: NonNullable<T[P]>;
 };
@@ -52,8 +61,8 @@ export type MutationTopicEditArgs = {
 };
 
 export type PaginationInput = {
-  page?: InputMaybe<Scalars['Int']['output']>;
-  recordsPerPage?: InputMaybe<Scalars['Int']['output']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  recordsPerPage?: InputMaybe<Scalars['Int']['input']>;
 };
 
 export type PaginationResult = {
@@ -116,8 +125,8 @@ export type TopicByIdResult = {
 };
 
 export type TopicCreateInput = {
-  name: Scalars['String']['output'];
-  url?: InputMaybe<Scalars['String']['output']>;
+  name: Scalars['String']['input'];
+  url?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type TopicCreatePayload = StandardError | TopicCreateResult;
@@ -128,9 +137,9 @@ export type TopicCreateResult = {
 };
 
 export type TopicEditInput = {
-  id: Scalars['ID']['output'];
-  name: Scalars['String']['output'];
-  url?: InputMaybe<Scalars['String']['output']>;
+  id: Scalars['ID']['input'];
+  name: Scalars['String']['input'];
+  url?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type TopicEditPayload = StandardError | TopicEditResult;
@@ -141,7 +150,7 @@ export type TopicEditResult = {
 };
 
 export type TopicsCreatedByUserInput = {
-  userId: Scalars['ID']['output'];
+  userId: Scalars['ID']['input'];
 };
 
 export type TopicsCreatedByUserPayload =

--- a/packages/typescript-resolver-files-e2e/src/test-modules/modules/base/resolvers/Error.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-modules/modules/base/resolvers/Error.ts
@@ -1,0 +1,4 @@
+import type { ErrorResolvers } from './../../types.generated';
+export const Error: ErrorResolvers = {
+  /* Implement Error interface logic here */
+};

--- a/packages/typescript-resolver-files-e2e/src/test-modules/modules/resolvers.generated.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-modules/modules/resolvers.generated.ts
@@ -1,5 +1,6 @@
 /* This file was automatically generated. DO NOT UPDATE MANUALLY. */
 import type { Resolvers } from './types.generated';
+import { Error } from './base/resolvers/Error';
 import { topicCreate as Mutation_topicCreate } from './topic/resolvers/Mutation/topicCreate';
 import { topicEdit as Mutation_topicEdit } from './topic/resolvers/Mutation/topicEdit';
 import { PaginationResult } from './base/resolvers/PaginationResult';
@@ -35,6 +36,7 @@ export const resolvers: Resolvers = {
     topicEdit: Mutation_topicEdit,
   },
   Subscription: { profileChanges: Subscription_profileChanges },
+  Error: Error,
   PaginationResult: PaginationResult,
   Profile: Profile,
   StandardError: StandardError,

--- a/packages/typescript-resolver-files-e2e/src/test-modules/modules/types.generated.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-modules/modules/types.generated.ts
@@ -16,6 +16,15 @@ export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
   [SubKey in K]: Maybe<T[SubKey]>;
 };
+export type MakeEmpty<
+  T extends { [key: string]: unknown },
+  K extends keyof T
+> = { [_ in K]?: never };
+export type Incremental<T> =
+  | T
+  | {
+      [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never;
+    };
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 export type RequireFields<T, K extends keyof T> = Omit<T, K> & {
   [P in K]-?: NonNullable<T[P]>;
@@ -55,8 +64,8 @@ export type MutationTopicEditArgs = {
 };
 
 export type PaginationInput = {
-  page?: InputMaybe<Scalars['Int']['output']>;
-  recordsPerPage?: InputMaybe<Scalars['Int']['output']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  recordsPerPage?: InputMaybe<Scalars['Int']['input']>;
 };
 
 export type PaginationResult = {
@@ -119,8 +128,8 @@ export type TopicByIdResult = {
 };
 
 export type TopicCreateInput = {
-  name: Scalars['String']['output'];
-  url?: InputMaybe<Scalars['String']['output']>;
+  name: Scalars['String']['input'];
+  url?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type TopicCreatePayload = StandardError | TopicCreateResult;
@@ -131,9 +140,9 @@ export type TopicCreateResult = {
 };
 
 export type TopicEditInput = {
-  id: Scalars['ID']['output'];
-  name: Scalars['String']['output'];
-  url?: InputMaybe<Scalars['String']['output']>;
+  id: Scalars['ID']['input'];
+  name: Scalars['String']['input'];
+  url?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type TopicEditPayload = StandardError | TopicEditResult;
@@ -144,7 +153,7 @@ export type TopicEditResult = {
 };
 
 export type TopicsCreatedByUserInput = {
-  userId: Scalars['ID']['output'];
+  userId: Scalars['ID']['input'];
 };
 
 export type TopicsCreatedByUserPayload =

--- a/packages/typescript-resolver-files-e2e/src/test-scalars-module/schema-overrides/base/resolvers/Error.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-scalars-module/schema-overrides/base/resolvers/Error.ts
@@ -1,0 +1,4 @@
+import type { ErrorResolvers } from './../../types.generated';
+export const Error: ErrorResolvers = {
+  /* Implement Error interface logic here */
+};

--- a/packages/typescript-resolver-files-e2e/src/test-scalars-module/schema-overrides/resolvers.generated.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-scalars-module/schema-overrides/resolvers.generated.ts
@@ -1,5 +1,6 @@
 /* This file was automatically generated. DO NOT UPDATE MANUALLY. */
 import type { Resolvers } from './types.generated';
+import { Error } from './base/resolvers/Error';
 import { topicCreate as Mutation_topicCreate } from './topic/resolvers/Mutation/topicCreate';
 import { topicEdit as Mutation_topicEdit } from './topic/resolvers/Mutation/topicEdit';
 import { PaginationResult } from './base/resolvers/PaginationResult';
@@ -36,6 +37,7 @@ export const resolvers: Resolvers = {
     topicEdit: Mutation_topicEdit,
   },
   Subscription: { profileChanges: Subscription_profileChanges },
+  Error: Error,
   PaginationResult: PaginationResult,
   PayloadError: PayloadError,
   Profile: Profile,

--- a/packages/typescript-resolver-files-e2e/src/test-scalars-module/schema-overrides/types.generated.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-scalars-module/schema-overrides/types.generated.ts
@@ -15,6 +15,15 @@ export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
   [SubKey in K]: Maybe<T[SubKey]>;
 };
+export type MakeEmpty<
+  T extends { [key: string]: unknown },
+  K extends keyof T
+> = { [_ in K]?: never };
+export type Incremental<T> =
+  | T
+  | {
+      [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never;
+    };
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 export type RequireFields<T, K extends keyof T> = Omit<T, K> & {
   [P in K]-?: NonNullable<T[P]>;
@@ -55,8 +64,8 @@ export type MutationTopicEditArgs = {
 };
 
 export type PaginationInput = {
-  page?: InputMaybe<Scalars['Int']['output']>;
-  recordsPerPage?: InputMaybe<Scalars['Int']['output']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  recordsPerPage?: InputMaybe<Scalars['Int']['input']>;
 };
 
 export type PaginationResult = {
@@ -119,8 +128,8 @@ export type TopicByIdResult = {
 };
 
 export type TopicCreateInput = {
-  name: Scalars['String']['output'];
-  url?: InputMaybe<Scalars['String']['output']>;
+  name: Scalars['String']['input'];
+  url?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type TopicCreatePayload = PayloadError | TopicCreateResult;
@@ -131,9 +140,9 @@ export type TopicCreateResult = {
 };
 
 export type TopicEditInput = {
-  id: Scalars['ID']['output'];
-  name: Scalars['String']['output'];
-  url?: InputMaybe<Scalars['String']['output']>;
+  id: Scalars['ID']['input'];
+  name: Scalars['String']['input'];
+  url?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type TopicEditPayload = PayloadError | TopicEditResult;
@@ -144,7 +153,7 @@ export type TopicEditResult = {
 };
 
 export type TopicsCreatedByUserInput = {
-  userId: Scalars['ID']['output'];
+  userId: Scalars['ID']['input'];
 };
 
 export type TopicsCreatedByUserPayload =

--- a/packages/typescript-resolver-files-e2e/src/test-scalars-module/schema/base/resolvers/Error.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-scalars-module/schema/base/resolvers/Error.ts
@@ -1,0 +1,4 @@
+import type { ErrorResolvers } from './../../types.generated';
+export const Error: ErrorResolvers = {
+  /* Implement Error interface logic here */
+};

--- a/packages/typescript-resolver-files-e2e/src/test-scalars-module/schema/resolvers.generated.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-scalars-module/schema/resolvers.generated.ts
@@ -1,6 +1,7 @@
 /* This file was automatically generated. DO NOT UPDATE MANUALLY. */
 import type { Resolvers } from './types.generated';
 import { DateTime } from './base/resolvers/DateTime';
+import { Error } from './base/resolvers/Error';
 import { topicCreate as Mutation_topicCreate } from './topic/resolvers/Mutation/topicCreate';
 import { topicEdit as Mutation_topicEdit } from './topic/resolvers/Mutation/topicEdit';
 import { PaginationResult } from './base/resolvers/PaginationResult';
@@ -37,6 +38,7 @@ export const resolvers: Resolvers = {
   },
   Subscription: { profileChanges: Subscription_profileChanges },
   DateTime: DateTime,
+  Error: Error,
   PaginationResult: PaginationResult,
   PayloadError: PayloadError,
   Profile: Profile,

--- a/packages/typescript-resolver-files-e2e/src/test-scalars-module/schema/types.generated.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-scalars-module/schema/types.generated.ts
@@ -15,6 +15,15 @@ export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
   [SubKey in K]: Maybe<T[SubKey]>;
 };
+export type MakeEmpty<
+  T extends { [key: string]: unknown },
+  K extends keyof T
+> = { [_ in K]?: never };
+export type Incremental<T> =
+  | T
+  | {
+      [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never;
+    };
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 export type RequireFields<T, K extends keyof T> = Omit<T, K> & {
   [P in K]-?: NonNullable<T[P]>;
@@ -55,8 +64,8 @@ export type MutationTopicEditArgs = {
 };
 
 export type PaginationInput = {
-  page?: InputMaybe<Scalars['Int']['output']>;
-  recordsPerPage?: InputMaybe<Scalars['Int']['output']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  recordsPerPage?: InputMaybe<Scalars['Int']['input']>;
 };
 
 export type PaginationResult = {
@@ -119,8 +128,8 @@ export type TopicByIdResult = {
 };
 
 export type TopicCreateInput = {
-  name: Scalars['String']['output'];
-  url?: InputMaybe<Scalars['String']['output']>;
+  name: Scalars['String']['input'];
+  url?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type TopicCreatePayload = PayloadError | TopicCreateResult;
@@ -131,9 +140,9 @@ export type TopicCreateResult = {
 };
 
 export type TopicEditInput = {
-  id: Scalars['ID']['output'];
-  name: Scalars['String']['output'];
-  url?: InputMaybe<Scalars['String']['output']>;
+  id: Scalars['ID']['input'];
+  name: Scalars['String']['input'];
+  url?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type TopicEditPayload = PayloadError | TopicEditResult;
@@ -144,7 +153,7 @@ export type TopicEditResult = {
 };
 
 export type TopicsCreatedByUserInput = {
-  userId: Scalars['ID']['output'];
+  userId: Scalars['ID']['input'];
 };
 
 export type TopicsCreatedByUserPayload =

--- a/packages/typescript-resolver-files-e2e/src/test-whitelisted/modules-typedefs-file-mode-mergedWhitelisted/base/resolvers/Error.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-whitelisted/modules-typedefs-file-mode-mergedWhitelisted/base/resolvers/Error.ts
@@ -1,0 +1,4 @@
+import type { ErrorResolvers } from './../../types.generated';
+export const Error: ErrorResolvers = {
+  /* Implement Error interface logic here */
+};

--- a/packages/typescript-resolver-files-e2e/src/test-whitelisted/modules-typedefs-file-mode-mergedWhitelisted/resolvers.generated.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-whitelisted/modules-typedefs-file-mode-mergedWhitelisted/resolvers.generated.ts
@@ -1,9 +1,11 @@
 /* This file was automatically generated. DO NOT UPDATE MANUALLY. */
 import type { Resolvers } from './types.generated';
+import { Error } from './base/resolvers/Error';
 import { PaginationResult } from './base/resolvers/PaginationResult';
 import { StandardError } from './base/resolvers/StandardError';
 import { DateTimeResolver } from 'graphql-scalars';
 export const resolvers: Resolvers = {
+  Error: Error,
   PaginationResult: PaginationResult,
   StandardError: StandardError,
   DateTime: DateTimeResolver,

--- a/packages/typescript-resolver-files-e2e/src/test-whitelisted/modules-typedefs-file-mode-mergedWhitelisted/types.generated.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-whitelisted/modules-typedefs-file-mode-mergedWhitelisted/types.generated.ts
@@ -14,6 +14,15 @@ export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
   [SubKey in K]: Maybe<T[SubKey]>;
 };
+export type MakeEmpty<
+  T extends { [key: string]: unknown },
+  K extends keyof T
+> = { [_ in K]?: never };
+export type Incremental<T> =
+  | T
+  | {
+      [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never;
+    };
 export type RequireFields<T, K extends keyof T> = Omit<T, K> & {
   [P in K]-?: NonNullable<T[P]>;
 };
@@ -53,8 +62,8 @@ export type MutationTopicEditArgs = {
 };
 
 export type PaginationInput = {
-  page?: InputMaybe<Scalars['Int']['output']>;
-  recordsPerPage?: InputMaybe<Scalars['Int']['output']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  recordsPerPage?: InputMaybe<Scalars['Int']['input']>;
 };
 
 export type PaginationResult = {
@@ -106,8 +115,8 @@ export type TopicByIdResult = {
 };
 
 export type TopicCreateInput = {
-  name: Scalars['String']['output'];
-  url?: InputMaybe<Scalars['String']['output']>;
+  name: Scalars['String']['input'];
+  url?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type TopicCreatePayload = StandardError | TopicCreateResult;
@@ -118,9 +127,9 @@ export type TopicCreateResult = {
 };
 
 export type TopicEditInput = {
-  id: Scalars['ID']['output'];
-  name: Scalars['String']['output'];
-  url?: InputMaybe<Scalars['String']['output']>;
+  id: Scalars['ID']['input'];
+  name: Scalars['String']['input'];
+  url?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type TopicEditPayload = StandardError | TopicEditResult;
@@ -131,7 +140,7 @@ export type TopicEditResult = {
 };
 
 export type TopicsCreatedByUserInput = {
-  userId: Scalars['ID']['output'];
+  userId: Scalars['ID']['input'];
 };
 
 export type TopicsCreatedByUserPayload =

--- a/packages/typescript-resolver-files-e2e/src/test-whitelisted/modules/base/resolvers/Error.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-whitelisted/modules/base/resolvers/Error.ts
@@ -1,0 +1,4 @@
+import type { ErrorResolvers } from './../../types.generated';
+export const Error: ErrorResolvers = {
+  /* Implement Error interface logic here */
+};

--- a/packages/typescript-resolver-files-e2e/src/test-whitelisted/modules/resolvers.generated.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-whitelisted/modules/resolvers.generated.ts
@@ -1,9 +1,11 @@
 /* This file was automatically generated. DO NOT UPDATE MANUALLY. */
 import type { Resolvers } from './types.generated';
+import { Error } from './base/resolvers/Error';
 import { PaginationResult } from './base/resolvers/PaginationResult';
 import { StandardError } from './base/resolvers/StandardError';
 import { DateTimeResolver } from 'graphql-scalars';
 export const resolvers: Resolvers = {
+  Error: Error,
   PaginationResult: PaginationResult,
   StandardError: StandardError,
   DateTime: DateTimeResolver,

--- a/packages/typescript-resolver-files-e2e/src/test-whitelisted/modules/types.generated.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-whitelisted/modules/types.generated.ts
@@ -14,6 +14,15 @@ export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
   [SubKey in K]: Maybe<T[SubKey]>;
 };
+export type MakeEmpty<
+  T extends { [key: string]: unknown },
+  K extends keyof T
+> = { [_ in K]?: never };
+export type Incremental<T> =
+  | T
+  | {
+      [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never;
+    };
 export type RequireFields<T, K extends keyof T> = Omit<T, K> & {
   [P in K]-?: NonNullable<T[P]>;
 };
@@ -53,8 +62,8 @@ export type MutationTopicEditArgs = {
 };
 
 export type PaginationInput = {
-  page?: InputMaybe<Scalars['Int']['output']>;
-  recordsPerPage?: InputMaybe<Scalars['Int']['output']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  recordsPerPage?: InputMaybe<Scalars['Int']['input']>;
 };
 
 export type PaginationResult = {
@@ -106,8 +115,8 @@ export type TopicByIdResult = {
 };
 
 export type TopicCreateInput = {
-  name: Scalars['String']['output'];
-  url?: InputMaybe<Scalars['String']['output']>;
+  name: Scalars['String']['input'];
+  url?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type TopicCreatePayload = StandardError | TopicCreateResult;
@@ -118,9 +127,9 @@ export type TopicCreateResult = {
 };
 
 export type TopicEditInput = {
-  id: Scalars['ID']['output'];
-  name: Scalars['String']['output'];
-  url?: InputMaybe<Scalars['String']['output']>;
+  id: Scalars['ID']['input'];
+  name: Scalars['String']['input'];
+  url?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type TopicEditPayload = StandardError | TopicEditResult;
@@ -131,7 +140,7 @@ export type TopicEditResult = {
 };
 
 export type TopicsCreatedByUserInput = {
-  userId: Scalars['ID']['output'];
+  userId: Scalars['ID']['input'];
 };
 
 export type TopicsCreatedByUserPayload =

--- a/packages/typescript-resolver-files/DEVELOPMENT.md
+++ b/packages/typescript-resolver-files/DEVELOPMENT.md
@@ -28,7 +28,7 @@ nx test typescript-resolver-files
 Create new e2e test setup (with own `codegen.yml` and schema files) from template:
 
 ```bash
-nx workspace-generator typescript-resolver-files-add-e2e-test <test-name-in-kebab-case>
+nx g @graphql-code-generator-plugins/workspace-plugin:typescript-resolver-files-add-e2e-test <test-name-in-kebab-case>
 ```
 
 #### Run E2E Test/s
@@ -47,7 +47,3 @@ nx e2e-run typescript-resolver-files-e2e -c clean-run
 # Run tests and assert. This is run in CI/CD.
 nx e2e typescript-resolver-files-e2e
 ```
-
-## TODOs
-
-- [ ] Add Interface handler

--- a/packages/typescript-resolver-files/src/generateResolverFiles/generateResolverFiles.ts
+++ b/packages/typescript-resolver-files/src/generateResolverFiles/generateResolverFiles.ts
@@ -6,6 +6,7 @@ import { handleGraphQLRootObjectTypeField } from './handleGraphQLRootObjectTypeF
 import { handleGraphQLObjectType } from './handleGraphQLObjectType';
 import { handleGraphQLUnionType } from './handleGraphQLUnionType';
 import { handleGraphQLScalarType } from './handleGraphQLScalarType';
+import { handleGraphQLInterfaceType } from './handleGraphQLInterfaceType';
 import { visitNamedType, VisitNamedTypeParams } from './visitNamedType';
 import type { GenerateResolverFilesContext } from './types';
 
@@ -26,6 +27,7 @@ export const generateResolverFiles = (
         ObjectType: handleGraphQLObjectType,
         UnionType: handleGraphQLUnionType,
         ScalarType: handleGraphQLScalarType,
+        InterfaceType: handleGraphQLInterfaceType,
       };
 
       if (isRootObjectType(schemaType) && isObjectType(namedType)) {

--- a/packages/typescript-resolver-files/src/generateResolverFiles/handleGraphQLInterfaceType.ts
+++ b/packages/typescript-resolver-files/src/generateResolverFiles/handleGraphQLInterfaceType.ts
@@ -1,0 +1,33 @@
+import { printImportLine } from '../utils';
+import type { GraphQLTypeHandler } from './types';
+
+export const handleGraphQLInterfaceType: GraphQLTypeHandler = (
+  {
+    fieldFilePath,
+    resolverName,
+    normalizedResolverName,
+    resolversTypeMeta,
+    moduleName,
+  },
+  { result, config: { emitLegacyCommonJSImports } }
+) => {
+  const variableStatement = `export const ${resolverName}: ${resolversTypeMeta.typeString} = { /* Implement ${resolverName} interface logic here */ };`;
+
+  result.files[fieldFilePath] = {
+    __filetype: 'generalResolver',
+    content: `
+    ${printImportLine({
+      isTypeImport: true,
+      module: resolversTypeMeta.module,
+      namedImports: [resolversTypeMeta.typeNamedImport],
+      emitLegacyCommonJSImports,
+    })}
+    ${variableStatement}`,
+    mainImportIdentifier: resolverName,
+    meta: {
+      moduleName,
+      normalizedResolverName,
+      variableStatement,
+    },
+  };
+};

--- a/packages/typescript-resolver-files/src/generateResolverFiles/visitNamedType.ts
+++ b/packages/typescript-resolver-files/src/generateResolverFiles/visitNamedType.ts
@@ -1,6 +1,7 @@
 import * as path from 'path';
 import {
   GraphQLNamedType,
+  isInterfaceType,
   isObjectType,
   isScalarType,
   isUnionType,
@@ -27,6 +28,7 @@ export interface VisitNamedTypeParams {
     ObjectType: GraphQLTypeHandler;
     ScalarType: GraphQLTypeHandler;
     UnionType: GraphQLTypeHandler;
+    InterfaceType: GraphQLTypeHandler;
   };
   location?: Location;
 }
@@ -96,6 +98,8 @@ export const visitNamedType = (
       visitor['UnionType'](visitorHandlerParams, ctx);
     } else if (isScalarType(namedType)) {
       visitor['ScalarType'](visitorHandlerParams, ctx);
+    } else if (isInterfaceType(namedType)) {
+      visitor['InterfaceType'](visitorHandlerParams, ctx);
     }
   }
 };


### PR DESCRIPTION
This was not initially added because we wanted to wait for non-optional `__typename` to be merged.