### PR TITLE
Support the case where type mapper is a class

### DIFF
--- a/packages/typescript-resolver-files/src/generateResolverFiles/ensureObjectTypeResolversAreGenerated.spec.ts
+++ b/packages/typescript-resolver-files/src/generateResolverFiles/ensureObjectTypeResolversAreGenerated.spec.ts
@@ -176,4 +176,175 @@ describe('ensureObjectTypeResolversAreGenerated()', () => {
           };"
     `);
   });
+
+  it('adds missing field resolvers, if necessary, when Mapper is a Class', () => {
+    const project = new Project();
+    project.createSourceFile(
+      createFilePath('user.mappers.ts'),
+      `export class UserMapper {
+        id: number;
+        firstName: string;
+        lastName: string;
+        role: 'ADMIN' | 'USER';
+        createdAt: Date;
+      }`
+    );
+    project.createSourceFile(
+      createFilePath('types.generated.ts'),
+      `
+      import { UserMapper } from './user.mappers';
+      export type Maybe<T> = T | null;
+      export type InputMaybe<T> = Maybe<T>;
+      export type Exact<T extends { [key: string]: unknown }> = {
+        [K in keyof T]: T[K];
+      };
+      export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
+        [SubKey in K]?: Maybe<T[SubKey]>;
+      };
+      export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
+        [SubKey in K]: Maybe<T[SubKey]>;
+      };
+      /** All built-in and custom scalars, mapped to their actual values */
+      export type Scalars = {
+        ID: string;
+        String: string;
+        Boolean: boolean;
+        Int: number;
+        Float: number;
+        DateTime: Date | string;
+      };
+      
+      export type Query = {
+        __typename: 'Query';
+        me?: Maybe<User>;
+      };
+      
+      export type User = {
+        __typename: 'User';
+        accountGitHub?: Maybe<Scalars['String']>;
+        accountGoogle?: Maybe<Scalars['String']>;
+        createdAt: Scalars['DateTime'];
+        fullName: Scalars['String'];
+        id: Scalars['ID'];
+        role: UserRole;
+      };
+      
+      export type UserRole = 'ADMIN' | 'USER';
+      
+      export type ResolverTypeWrapper<T> = Promise<T> | T;
+      
+      export type ResolverWithResolve<TResult, TParent, TContext, TArgs> = {
+        resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
+      };
+      export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> =
+        | ResolverFn<TResult, TParent, TContext, TArgs>
+        | ResolverWithResolve<TResult, TParent, TContext, TArgs>;
+      
+      export type ResolverFn<TResult, TParent, TContext, TArgs> = (
+        parent: TParent,
+        args: TArgs,
+        context: TContext,
+        info: any
+      ) => Promise<TResult> | TResult;
+      
+      /** Mapping between all available schema types and the resolvers types */
+      export type ResolversTypes = {
+        DateTime: ResolverTypeWrapper<Scalars['DateTime']>;
+        Query: ResolverTypeWrapper<{}>;
+        User: ResolverTypeWrapper<UserMapper>;
+        String: ResolverTypeWrapper<Scalars['String']>;
+        ID: ResolverTypeWrapper<Scalars['ID']>;
+        UserRole: UserRole;
+        Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
+      };
+      
+      /** Mapping between all available schema types and the resolvers parents */
+      export type ResolversParentTypes = {
+        DateTime: Scalars['DateTime'];
+        Query: {};
+        User: UserMapper;
+        String: Scalars['String'];
+        ID: Scalars['ID'];
+        Boolean: Scalars['Boolean'];
+      };
+      
+      export type UserResolvers<
+        ContextType = any,
+        ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User']
+      > = {
+        accountGitHub?: Resolver<
+          Maybe<ResolversTypes['String']>,
+          ParentType,
+          ContextType
+        >;
+        accountGoogle?: Resolver<
+          Maybe<ResolversTypes['String']>,
+          ParentType,
+          ContextType
+        >;
+        createdAt?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
+        fullName?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+        role?: Resolver<ResolversTypes['UserRole'], ParentType, ContextType>;
+        __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+      };
+    `
+    );
+
+    const sourceFile = project.createSourceFile(
+      createFilePath('User.ts'),
+      `import type { UserResolvers } from './types.generated';
+      export const User: UserResolvers = {
+        /* Implement logic here */
+      };`
+    );
+
+    ensureObjectTypeResolversAreGenerated(sourceFile, {
+      __filetype: 'objectType',
+      content: '',
+      mainImportIdentifier: 'User',
+      meta: {
+        moduleName: 'user',
+        normalizedResolverName: '',
+        variableStatement: '',
+        resolversToGenerate: {
+          id: {
+            resolverName: 'id',
+            resolverDeclaration: `({ id }) => id`,
+          },
+          createdAt: {
+            resolverName: 'createdAt',
+            resolverDeclaration: `({ createdAt }) => createdAt`,
+          },
+          accountGitHub: {
+            resolverName: 'accountGitHub',
+            resolverDeclaration: `({ accountGitHub }) => accountGitHub`,
+          },
+          accountGoogle: {
+            resolverName: 'accountGoogle',
+            resolverDeclaration: `({ accountGoogle }) => accountGoogle`,
+          },
+          fullName: {
+            resolverName: 'fullName',
+            resolverDeclaration: `({ fullName }) => fullName`,
+          },
+          role: {
+            resolverName: 'role',
+            resolverDeclaration: `({ role }) => role`,
+          },
+        },
+      },
+    });
+
+    expect(sourceFile.getText()).toMatchInlineSnapshot(`
+      "import type { UserResolvers } from './types.generated';
+            export const User: UserResolvers = {
+              /* Implement logic here */
+                id: ({ id }) => id,
+                accountGitHub: ({ accountGitHub }) => accountGitHub,
+                accountGoogle: ({ accountGoogle }) => accountGoogle,
+                fullName: ({ fullName }) => fullName
+          };"
+    `);
+  });
 });

--- a/packages/typescript-resolver-files/src/parseTypeMappers/collectTypeMappersFromSourceFile.spec.ts
+++ b/packages/typescript-resolver-files/src/parseTypeMappers/collectTypeMappersFromSourceFile.spec.ts
@@ -540,6 +540,8 @@ describe('collectTypeMappersFromSourceFile', () => {
         private tsPrivateField: string;
         private readonly tsPrivateReadonlyField: string;
         #ecmaPrivateField: string;
+        method(): string
+        get getter(): string
       }
 
       export class NotMapperInlineExport1 {
@@ -552,7 +554,7 @@ describe('collectTypeMappersFromSourceFile', () => {
 
       class Base {
         id: string;
-        title: string;
+        private title: string;
       }
 
       class Like extends Base {
@@ -579,16 +581,13 @@ describe('collectTypeMappersFromSourceFile', () => {
     );
 
     expect(result).toEqual({
-      User: {
-        configImportPath: './module1/schema.mappers#UserTypeMapper',
-        schemaType: 'User',
-        typeMapperName: 'UserTypeMapper',
+      Like: {
+        configImportPath: './module1/schema.mappers#LikeTypeMapper',
+        schemaType: 'Like',
+        typeMapperName: 'LikeTypeMapper',
         typeMapperPropertyMap: {
           id: { name: 'id' },
-          firstName: { name: 'firstName' },
-          lastName: { name: 'lastName' },
           createdAt: { name: 'createdAt' },
-          updatedAt: { name: 'updatedAt' },
         },
       },
       Post: {
@@ -599,14 +598,16 @@ describe('collectTypeMappersFromSourceFile', () => {
           id: { name: 'id' },
         },
       },
-      Like: {
-        configImportPath: './module1/schema.mappers#LikeTypeMapper',
-        schemaType: 'Like',
-        typeMapperName: 'LikeTypeMapper',
+      User: {
+        configImportPath: './module1/schema.mappers#UserTypeMapper',
+        schemaType: 'User',
+        typeMapperName: 'UserTypeMapper',
         typeMapperPropertyMap: {
           id: { name: 'id' },
-          title: { name: 'title' },
+          firstName: { name: 'firstName' },
+          lastName: { name: 'lastName' },
           createdAt: { name: 'createdAt' },
+          updatedAt: { name: 'updatedAt' },
         },
       },
     });

--- a/packages/typescript-resolver-files/src/parseTypeMappers/collectTypeMappersFromSourceFile.ts
+++ b/packages/typescript-resolver-files/src/parseTypeMappers/collectTypeMappersFromSourceFile.ts
@@ -95,6 +95,30 @@ export const collectTypeMappersFromSourceFile = (
       );
     });
   });
+
+  typeMappersSourceFile.getClasses().forEach((classDeclaration) => {
+    if (!classDeclaration.hasExportKeyword()) {
+      return;
+    }
+    const identifierNode = classDeclaration.getNameNode();
+    if (!identifierNode) {
+      // Anonymous class is skipped
+      return;
+    }
+
+    addTypeMapperDetailsIfValid(
+      {
+        declarationNode: null,
+        identifierNode,
+        typeMappersSuffix,
+        typeMappersFilePath: typeMappersSourceFile.getFilePath(),
+        resolverTypesPath,
+        shouldCollectPropertyMap,
+        emitLegacyCommonJSImports,
+      },
+      result
+    );
+  });
 };
 
 const addTypeMapperDetailsIfValid = (

--- a/packages/typescript-resolver-files/src/utils/getNodePropertyMap.ts
+++ b/packages/typescript-resolver-files/src/utils/getNodePropertyMap.ts
@@ -1,3 +1,4 @@
+import { ClassDeclaration } from 'ts-morph';
 import { type TypeNode, Node, SyntaxKind } from 'ts-morph';
 
 export type NodePropertyMap = Record<string, { name: string }>;
@@ -38,6 +39,10 @@ const getNodeProperties = (node: Node): Properties => {
     const properties: Properties = [];
     collectTypeNodeProperties(typeNode, properties);
     return properties;
+  } else if (node.isKind(SyntaxKind.ClassDeclaration)) {
+    const properties: Properties = [];
+    collectClassNodeProperties(node, properties);
+    return properties;
   }
   return [];
 };
@@ -62,4 +67,32 @@ const collectTypeNodeProperties = (
       collectTypeNodeProperties(typeNode, result); // May contain duplicated properties from different typeNodes. Will be deduped in getNodePropertyMap.
     });
   }
+};
+
+const collectClassNodeProperties = (
+  classNode: ClassDeclaration,
+  result: Properties
+): void => {
+  const baseClass = classNode.getBaseClass();
+  if (baseClass) {
+    collectClassNodeProperties(baseClass, result);
+  }
+
+  classNode.getInstanceProperties().forEach((prop) => {
+    if (
+      prop.hasModifier(SyntaxKind.PrivateKeyword) ||
+      prop.hasModifier(SyntaxKind.ProtectedKeyword)
+    ) {
+      return;
+    }
+    if (prop.getName().startsWith('#')) {
+      // ecma script private field is skipped
+      return;
+    }
+    if (classNode.getGetAccessor(prop.getName())) {
+      // getter is skipped
+      return;
+    }
+    result.push({ propertyName: prop.getName() });
+  });
 };


### PR DESCRIPTION
Hi @eddeee888 .
Sorry for the sudden creation of this PR.

Currently, Type Mapper correctly generates missing resolvers only for Type or Interface, but when Type Mapper is a class, it recognizes all fields as missing resolvers.

Below is a specific example

```graphql
# schema.graphql
type User {
  id: ID!
  name: String!
}
```

```typescript
// schema.mappers.ts

export class UserMapper {
  id: string
  name: string
}
```

```typescript
// resolvers/User.ts
import type { UserResolvers } from './types.generated';

export const User: UserResolvers = {
  /* Implement logic here */
  id: () => { /* User.id resolver is required because User.firstName exists but UserMapper.id does not */ },
  name: () => { /* User.name resolver is required because User.name exists but UserMapper.id does not */ },
  // If there were more fields, it would generate a lot of them...
};
```

I find this PR useful, at least for me, but I guess there is a reason why it has not been implemented so far, on the other hand?

Perhaps the scope of what I am able to consider may be narrower than I imagine. If so, I would very much appreciate your advice and feedback.
