### PR TITLE
🚧 support for extend non root operations

### DIFF
--- a/packages/typescript-resolver-files-e2e/project.json
+++ b/packages/typescript-resolver-files-e2e/project.json
@@ -102,6 +102,13 @@
             "rimraf -g 'packages/typescript-resolver-files-e2e/src/test-scalars-module/**/*.generated.*'"
           ],
           "parallel": false
+        },
+        "test-extend-non-query": {
+          "commands": [
+            "rimraf -g 'packages/typescript-resolver-files-e2e/src/test-extend-non-query/**/resolvers/'",
+            "rimraf -g 'packages/typescript-resolver-files-e2e/src/test-extend-non-query/**/*.generated.*'"
+          ],
+          "parallel": false
         }
       }
     },
@@ -120,7 +127,8 @@
           "nx graphql-codegen typescript-resolver-files-e2e -c test-modules-typedefs-file-mode --verbose",
           "nx graphql-codegen typescript-resolver-files-e2e -c test-modules-resolver-main-file-mode --verbose",
           "nx graphql-codegen typescript-resolver-files-e2e -c test-esm-import --verbose",
-          "nx graphql-codegen typescript-resolver-files-e2e -c test-scalars-module --verbose"
+          "nx graphql-codegen typescript-resolver-files-e2e -c test-scalars-module --verbose",
+          "nx graphql-codegen typescript-resolver-files-e2e -c test-extend-non-query --verbose"
         ],
         "parallel": false
       },
@@ -174,6 +182,9 @@
         },
         "test-scalars-module": {
           "configFile": "packages/typescript-resolver-files-e2e/src/test-scalars-module/codegen.ts"
+        },
+        "test-extend-non-query": {
+          "configFile": "packages/typescript-resolver-files-e2e/src/test-extend-non-query/codegen.yml"
         }
       },
       "dependsOn": ["^build"]

--- a/packages/typescript-resolver-files-e2e/src/test-extend-non-query/codegen.yml
+++ b/packages/typescript-resolver-files-e2e/src/test-extend-non-query/codegen.yml
@@ -1,0 +1,12 @@
+# https://www.graphql-code-generator.com/docs/config-reference/codegen-config
+schema:
+  - packages/typescript-resolver-files-e2e/src/test-extend-non-query/**/*.graphqls
+  - packages/typescript-resolver-files-e2e/src/test-extend-non-query/**/*.graphqls.ts
+hooks:
+  afterAllFileWrite:
+    - prettier --write
+generates:
+  packages/typescript-resolver-files-e2e/src/test-extend-non-query/modules:
+    preset: ./dist/packages/typescript-resolver-files/src/index.js
+    presetConfig:
+      enableExtendNonRootOperations: true

--- a/packages/typescript-resolver-files-e2e/src/test-extend-non-query/modules/post-extend-user/resolvers/Post.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-extend-non-query/modules/post-extend-user/resolvers/Post.ts
@@ -1,0 +1,4 @@
+import type { PostResolvers } from './../../types.generated';
+export const Post: PostResolvers = {
+  /* Implement Post resolver logic here */
+};

--- a/packages/typescript-resolver-files-e2e/src/test-extend-non-query/modules/post-extend-user/resolvers/User/posts.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-extend-non-query/modules/post-extend-user/resolvers/User/posts.ts
@@ -1,0 +1,9 @@
+import type { UserResolvers } from './../../../types.generated';
+
+export const posts: NonNullable<UserResolvers['posts']> = async (
+  _parent,
+  _arg,
+  _ctx
+) => {
+  /* Implement User.posts resolver logic here */
+};

--- a/packages/typescript-resolver-files-e2e/src/test-extend-non-query/modules/post-extend-user/schema.graphqls
+++ b/packages/typescript-resolver-files-e2e/src/test-extend-non-query/modules/post-extend-user/schema.graphqls
@@ -1,0 +1,8 @@
+type Post {
+  id: ID!
+  title: String!
+}
+
+extend type User {
+  posts: [Post!]!
+}

--- a/packages/typescript-resolver-files-e2e/src/test-extend-non-query/modules/resolvers.generated.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-extend-non-query/modules/resolvers.generated.ts
@@ -1,0 +1,9 @@
+/* This file was automatically generated. DO NOT UPDATE MANUALLY. */
+import type { Resolvers } from './types.generated';
+import { Post } from './post-extend-user/resolvers/Post';
+import { User } from './user/resolvers/User';
+import { posts as User_posts } from './post-extend-user/resolvers/User/posts';
+export const resolvers: Resolvers = {
+  Post: { ...Post },
+  User: { ...User, posts: User_posts },
+};

--- a/packages/typescript-resolver-files-e2e/src/test-extend-non-query/modules/typeDefs.generated.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-extend-non-query/modules/typeDefs.generated.ts
@@ -1,0 +1,134 @@
+import type { DocumentNode } from 'graphql';
+export const typeDefs = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'ObjectTypeDefinition',
+      name: { kind: 'Name', value: 'Post', loc: { start: 5, end: 9 } },
+      interfaces: [],
+      directives: [],
+      fields: [
+        {
+          kind: 'FieldDefinition',
+          name: { kind: 'Name', value: 'id', loc: { start: 14, end: 16 } },
+          arguments: [],
+          type: {
+            kind: 'NonNullType',
+            type: {
+              kind: 'NamedType',
+              name: { kind: 'Name', value: 'ID', loc: { start: 18, end: 20 } },
+              loc: { start: 18, end: 20 },
+            },
+            loc: { start: 18, end: 21 },
+          },
+          directives: [],
+          loc: { start: 14, end: 21 },
+        },
+        {
+          kind: 'FieldDefinition',
+          name: { kind: 'Name', value: 'title', loc: { start: 24, end: 29 } },
+          arguments: [],
+          type: {
+            kind: 'NonNullType',
+            type: {
+              kind: 'NamedType',
+              name: {
+                kind: 'Name',
+                value: 'String',
+                loc: { start: 31, end: 37 },
+              },
+              loc: { start: 31, end: 37 },
+            },
+            loc: { start: 31, end: 38 },
+          },
+          directives: [],
+          loc: { start: 24, end: 38 },
+        },
+      ],
+      loc: { start: 0, end: 40 },
+    },
+    {
+      kind: 'ObjectTypeExtension',
+      name: { kind: 'Name', value: 'User', loc: { start: 54, end: 58 } },
+      interfaces: [],
+      directives: [],
+      fields: [
+        {
+          kind: 'FieldDefinition',
+          name: { kind: 'Name', value: 'posts', loc: { start: 63, end: 68 } },
+          arguments: [],
+          type: {
+            kind: 'NonNullType',
+            type: {
+              kind: 'ListType',
+              type: {
+                kind: 'NonNullType',
+                type: {
+                  kind: 'NamedType',
+                  name: {
+                    kind: 'Name',
+                    value: 'Post',
+                    loc: { start: 71, end: 75 },
+                  },
+                  loc: { start: 71, end: 75 },
+                },
+                loc: { start: 71, end: 76 },
+              },
+              loc: { start: 70, end: 77 },
+            },
+            loc: { start: 70, end: 78 },
+          },
+          directives: [],
+          loc: { start: 63, end: 78 },
+        },
+      ],
+      loc: { start: 42, end: 80 },
+    },
+    {
+      kind: 'ObjectTypeDefinition',
+      name: { kind: 'Name', value: 'User', loc: { start: 86, end: 90 } },
+      interfaces: [],
+      directives: [],
+      fields: [
+        {
+          kind: 'FieldDefinition',
+          name: { kind: 'Name', value: 'id', loc: { start: 95, end: 97 } },
+          arguments: [],
+          type: {
+            kind: 'NonNullType',
+            type: {
+              kind: 'NamedType',
+              name: { kind: 'Name', value: 'ID', loc: { start: 99, end: 101 } },
+              loc: { start: 99, end: 101 },
+            },
+            loc: { start: 99, end: 102 },
+          },
+          directives: [],
+          loc: { start: 95, end: 102 },
+        },
+        {
+          kind: 'FieldDefinition',
+          name: { kind: 'Name', value: 'name', loc: { start: 105, end: 109 } },
+          arguments: [],
+          type: {
+            kind: 'NonNullType',
+            type: {
+              kind: 'NamedType',
+              name: {
+                kind: 'Name',
+                value: 'String',
+                loc: { start: 111, end: 117 },
+              },
+              loc: { start: 111, end: 117 },
+            },
+            loc: { start: 111, end: 118 },
+          },
+          directives: [],
+          loc: { start: 105, end: 118 },
+        },
+      ],
+      loc: { start: 81, end: 120 },
+    },
+  ],
+  loc: { start: 0, end: 121 },
+} as unknown as DocumentNode;

--- a/packages/typescript-resolver-files-e2e/src/test-extend-non-query/modules/types.generated.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-extend-non-query/modules/types.generated.ts
@@ -1,0 +1,189 @@
+import { GraphQLResolveInfo } from 'graphql';
+export type Maybe<T> = T | null;
+export type InputMaybe<T> = Maybe<T>;
+export type Exact<T extends { [key: string]: unknown }> = {
+  [K in keyof T]: T[K];
+};
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
+  [SubKey in K]?: Maybe<T[SubKey]>;
+};
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
+  [SubKey in K]: Maybe<T[SubKey]>;
+};
+export type MakeEmpty<
+  T extends { [key: string]: unknown },
+  K extends keyof T
+> = { [_ in K]?: never };
+export type Incremental<T> =
+  | T
+  | {
+      [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never;
+    };
+/** All built-in and custom scalars, mapped to their actual values */
+export type Scalars = {
+  ID: { input: string; output: string | number };
+  String: { input: string; output: string };
+  Boolean: { input: boolean; output: boolean };
+  Int: { input: number; output: number };
+  Float: { input: number; output: number };
+};
+
+export type Post = {
+  __typename?: 'Post';
+  id: Scalars['ID']['output'];
+  title: Scalars['String']['output'];
+};
+
+export type User = {
+  __typename?: 'User';
+  id: Scalars['ID']['output'];
+  name: Scalars['String']['output'];
+  posts: Array<Post>;
+};
+
+export type ResolverTypeWrapper<T> = Promise<T> | T;
+
+export type ResolverWithResolve<TResult, TParent, TContext, TArgs> = {
+  resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
+};
+export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> =
+  | ResolverFn<TResult, TParent, TContext, TArgs>
+  | ResolverWithResolve<TResult, TParent, TContext, TArgs>;
+
+export type ResolverFn<TResult, TParent, TContext, TArgs> = (
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => Promise<TResult> | TResult;
+
+export type SubscriptionSubscribeFn<TResult, TParent, TContext, TArgs> = (
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => AsyncIterable<TResult> | Promise<AsyncIterable<TResult>>;
+
+export type SubscriptionResolveFn<TResult, TParent, TContext, TArgs> = (
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => TResult | Promise<TResult>;
+
+export interface SubscriptionSubscriberObject<
+  TResult,
+  TKey extends string,
+  TParent,
+  TContext,
+  TArgs
+> {
+  subscribe: SubscriptionSubscribeFn<
+    { [key in TKey]: TResult },
+    TParent,
+    TContext,
+    TArgs
+  >;
+  resolve?: SubscriptionResolveFn<
+    TResult,
+    { [key in TKey]: TResult },
+    TContext,
+    TArgs
+  >;
+}
+
+export interface SubscriptionResolverObject<TResult, TParent, TContext, TArgs> {
+  subscribe: SubscriptionSubscribeFn<any, TParent, TContext, TArgs>;
+  resolve: SubscriptionResolveFn<TResult, any, TContext, TArgs>;
+}
+
+export type SubscriptionObject<
+  TResult,
+  TKey extends string,
+  TParent,
+  TContext,
+  TArgs
+> =
+  | SubscriptionSubscriberObject<TResult, TKey, TParent, TContext, TArgs>
+  | SubscriptionResolverObject<TResult, TParent, TContext, TArgs>;
+
+export type SubscriptionResolver<
+  TResult,
+  TKey extends string,
+  TParent = {},
+  TContext = {},
+  TArgs = {}
+> =
+  | ((
+      ...args: any[]
+    ) => SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>)
+  | SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>;
+
+export type TypeResolveFn<TTypes, TParent = {}, TContext = {}> = (
+  parent: TParent,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => Maybe<TTypes> | Promise<Maybe<TTypes>>;
+
+export type IsTypeOfResolverFn<T = {}, TContext = {}> = (
+  obj: T,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => boolean | Promise<boolean>;
+
+export type NextResolverFn<T> = () => Promise<T>;
+
+export type DirectiveResolverFn<
+  TResult = {},
+  TParent = {},
+  TContext = {},
+  TArgs = {}
+> = (
+  next: NextResolverFn<TResult>,
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => TResult | Promise<TResult>;
+
+/** Mapping between all available schema types and the resolvers types */
+export type ResolversTypes = {
+  Post: ResolverTypeWrapper<Post>;
+  ID: ResolverTypeWrapper<Scalars['ID']['output']>;
+  String: ResolverTypeWrapper<Scalars['String']['output']>;
+  User: ResolverTypeWrapper<User>;
+  Boolean: ResolverTypeWrapper<Scalars['Boolean']['output']>;
+};
+
+/** Mapping between all available schema types and the resolvers parents */
+export type ResolversParentTypes = {
+  Post: Post;
+  ID: Scalars['ID']['output'];
+  String: Scalars['String']['output'];
+  User: User;
+  Boolean: Scalars['Boolean']['output'];
+};
+
+export type PostResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['Post'] = ResolversParentTypes['Post']
+> = {
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  title?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type UserResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User']
+> = {
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  posts?: Resolver<Array<ResolversTypes['Post']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type Resolvers<ContextType = any> = {
+  Post?: PostResolvers<ContextType>;
+  User?: UserResolvers<ContextType>;
+};

--- a/packages/typescript-resolver-files-e2e/src/test-extend-non-query/modules/user/resolvers/User.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-extend-non-query/modules/user/resolvers/User.ts
@@ -1,0 +1,4 @@
+import type { UserResolvers } from './../../types.generated';
+export const User: UserResolvers = {
+  /* Implement User resolver logic here */
+};

--- a/packages/typescript-resolver-files-e2e/src/test-extend-non-query/modules/user/schema.graphqls
+++ b/packages/typescript-resolver-files-e2e/src/test-extend-non-query/modules/user/schema.graphqls
@@ -1,0 +1,4 @@
+type User {
+  id: ID!
+  name: String!
+}

--- a/packages/typescript-resolver-files/README.md
+++ b/packages/typescript-resolver-files/README.md
@@ -273,6 +273,12 @@ Statically compares object type's mapper types' field against schema types' fiel
 
 Determines whether imports emitted should use CommonJS syntax or ESM syntax (with `.js` file endings)
 
+### enableExtendNonRootOperations
+
+`bool` (Default: `false`)
+
+Determines whether to generate resolvers for non-root operations (e.g. `User` in `extend type User { ... }`)
+
 ## Config Examples
 
 #### 1. Custom Config

--- a/packages/typescript-resolver-files/src/validatePresetConfig/validatePresetConfig.spec.ts
+++ b/packages/typescript-resolver-files/src/validatePresetConfig/validatePresetConfig.spec.ts
@@ -21,6 +21,7 @@ const defaultExpected: ReturnType<typeof validatePresetConfig> = {
   },
   fixObjectTypeResolvers: 'smart',
   emitLegacyCommonJSImports: true,
+  enableExtendNonRootOperations: false,
 };
 
 describe('validatePresetConfig - general', () => {
@@ -213,6 +214,17 @@ describe('validatePresetConfig - general', () => {
     ).toThrowError(
       '[@eddeee888/gcg-typescript-resolver-files] ERROR: Validation - presetConfig.typesPluginsConfig.emitLegacyCommonJSImports is not supported. Use presetConfig.emitLegacyCommonJSImports instead.'
     );
+  });
+
+  it('returns result.enableExtendNonRootOperations = true if set to true', () => {
+    const parsed = validatePresetConfig({
+      enableExtendNonRootOperations: true,
+    });
+
+    expect(parsed).toEqual({
+      ...defaultExpected,
+      enableExtendNonRootOperations: true,
+    });
   });
 
   it('throws if result.fixObjectTypeResolvers is not valid', () => {

--- a/packages/typescript-resolver-files/src/validatePresetConfig/validatePresetConfig.ts
+++ b/packages/typescript-resolver-files/src/validatePresetConfig/validatePresetConfig.ts
@@ -49,6 +49,7 @@ export interface ParsedPresetConfig {
   tsMorphProjectOptions: ProjectOptions;
   fixObjectTypeResolvers: FixObjectTypeResolvers;
   emitLegacyCommonJSImports: boolean;
+  enableExtendNonRootOperations: boolean;
 }
 
 export interface RawPresetConfig {
@@ -74,6 +75,7 @@ export interface RawPresetConfig {
   tsConfigFilePath?: string;
   fixObjectTypeResolvers?: string;
   emitLegacyCommonJSImports?: boolean;
+  enableExtendNonRootOperations?: boolean;
 }
 
 export interface TypedPresetConfig extends RawPresetConfig {
@@ -103,6 +105,7 @@ export const validatePresetConfig = ({
   tsConfigFilePath = './tsconfig.json',
   fixObjectTypeResolvers = 'smart',
   emitLegacyCommonJSImports = true,
+  enableExtendNonRootOperations = false,
 }: RawPresetConfig): ParsedPresetConfig => {
   if (mode !== 'merged' && mode !== 'modules') {
     throw new Error(
@@ -263,6 +266,7 @@ export const validatePresetConfig = ({
     tsMorphProjectOptions,
     fixObjectTypeResolvers,
     emitLegacyCommonJSImports,
+    enableExtendNonRootOperations,
   };
 };
 


### PR DESCRIPTION
hi @eddeee888 

It would be very useful to be able to separate interests by schema like apollo federation.

```graphql
# User.graphql

type User {
  id: ID!
}
```

```graphql
# Post.graphql

type Post {
  id: ID!
}

extend type User {
  posts: [Post!]!
}
```

In this case, it is like `schema/post/resolvers/User/posts.ts` where individual resolvers are generated.

```typescript
import type { UserResolvers } from './../../../types.generated';

export const posts: NonNullable<UserResolvers['posts']> = async (
  _parent,
  _arg,
  _ctx
) => {
  /* Implement User.posts resolver logic here */
};
```

I described what the end result would ideally be as an e2e test, but I'm not sure how to actually write the code...

Can you give me some advices?