### PR TITLE
Stop running node 16.x in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ on:
 
 env:
   node-version: '18.x'
-  supported-node-versions: [18.x, 20.x]
 
 jobs:
   precheck:
@@ -50,7 +49,7 @@ jobs:
         os:
           - ubuntu-22.04
           - windows-latest
-        node-version: ${{ env.supported-node-versions }}
+        node-version: ${{ vars.SUPPORTED_NODE_VERSIONS }}
     runs-on: ${{ matrix.os }}
     needs: precheck
     if: ${{ needs.precheck.outputs.affected-typescript-resolver-files == 'true' }}
@@ -83,7 +82,7 @@ jobs:
         os:
           - ubuntu-22.04
           - windows-latest
-        node-version: ${{ env.supported-node-versions }}
+        node-version: ${{ vars.SUPPORTED_NODE_VERSIONS }}
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,9 +46,7 @@ jobs:
   typescript-resolver-files:
     strategy:
       matrix:
-        os:
-          - ubuntu-22.04
-          - windows-latest
+        os: [ubuntu-22.04, windows-latest]
         node-version: [18.x, 20.x]
     runs-on: ${{ matrix.os }}
     needs: precheck
@@ -79,9 +77,7 @@ jobs:
   typescript-resolver-files-e2e:
     strategy:
       matrix:
-        os:
-          - ubuntu-22.04
-          - windows-latest
+        os: [ubuntu-22.04, windows-latest]
         node-version: [18.x, 20.x]
     runs-on: ${{ matrix.os }}
     defaults:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   node-version: '18.x'
+  supported-node-versions: [18.x, 20.x]
 
 jobs:
   precheck:
@@ -49,7 +50,7 @@ jobs:
         os:
           - ubuntu-22.04
           - windows-latest
-        node-version: [16.x, 18.x, 20.x]
+        node-version: ${{ env.supported-node-versions }}
     runs-on: ${{ matrix.os }}
     needs: precheck
     if: ${{ needs.precheck.outputs.affected-typescript-resolver-files == 'true' }}
@@ -82,7 +83,7 @@ jobs:
         os:
           - ubuntu-22.04
           - windows-latest
-        node-version: [16.x, 18.x, 20.x]
+        node-version: ${{ env.supported-node-versions }}
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
         os:
           - ubuntu-22.04
           - windows-latest
-        node-version: ${{ vars.SUPPORTED_NODE_VERSIONS }}
+        node-version: [18.x, 20.x]
     runs-on: ${{ matrix.os }}
     needs: precheck
     if: ${{ needs.precheck.outputs.affected-typescript-resolver-files == 'true' }}
@@ -82,7 +82,7 @@ jobs:
         os:
           - ubuntu-22.04
           - windows-latest
-        node-version: ${{ vars.SUPPORTED_NODE_VERSIONS }}
+        node-version: [18.x, 20.x]
     runs-on: ${{ matrix.os }}
     defaults:
       run:


### PR DESCRIPTION
Node 16.x is no longer supported since Sept 11, 2023