### PR TITLE
always pick `__resolveReference` on extended types if federation is enabled and type has a `key` directive

### DIFF
--- a/.changeset/spotty-birds-raise.md
+++ b/.changeset/spotty-birds-raise.md
@@ -1,0 +1,5 @@
+---
+'@eddeee888/gcg-typescript-resolver-files': patch
+---
+
+Federation support: Add \_\_resolveReference to picked fields when extending object types

--- a/packages/typescript-resolver-files-e2e/src/test-extended-object-types/codegen.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-extended-object-types/codegen.ts
@@ -3,7 +3,7 @@ import { defineConfig } from '@eddeee888/gcg-typescript-resolver-files';
 
 const config: CodegenConfig = {
   hooks: {
-    afterAllFileWrite: ['prettier --write'],
+    afterOneFileWrite: ['prettier --write'],
   },
   generates: {
     'packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-base':
@@ -16,6 +16,7 @@ const config: CodegenConfig = {
           ],
         }
       ),
+
     'packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-external-resolver-override-extended-object-type':
       defineConfig(
         {
@@ -30,6 +31,7 @@ const config: CodegenConfig = {
           ],
         }
       ),
+
     'packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type':
       defineConfig(
         {

--- a/packages/typescript-resolver-files-e2e/src/test-extended-object-types/codegen.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-extended-object-types/codegen.ts
@@ -30,6 +30,20 @@ const config: CodegenConfig = {
           ],
         }
       ),
+    'packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type':
+      defineConfig(
+        {
+          typesPluginsConfig: {
+            federation: true,
+          },
+        },
+        {
+          schema: [
+            'packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type/**/*.graphqls',
+            'packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type/**/*.graphqls.ts',
+          ],
+        }
+      ),
   },
 };
 

--- a/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type/base/resolvers/PaginationResult.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type/base/resolvers/PaginationResult.ts
@@ -1,0 +1,4 @@
+import type { PaginationResultResolvers } from './../../types.generated';
+export const PaginationResult: PaginationResultResolvers = {
+  /* Implement PaginationResult resolver logic here */
+};

--- a/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type/base/resolvers/PayloadError.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type/base/resolvers/PayloadError.ts
@@ -1,0 +1,4 @@
+import type { PayloadErrorResolvers } from './../../types.generated';
+export const PayloadError: PayloadErrorResolvers = {
+  /* Implement PayloadError resolver logic here */
+};

--- a/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type/base/resolvers/SomeRandomScalar.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type/base/resolvers/SomeRandomScalar.ts
@@ -1,0 +1,14 @@
+import { GraphQLScalarType } from 'graphql';
+export const SomeRandomScalar = new GraphQLScalarType({
+  name: 'SomeRandomScalar',
+  description: 'SomeRandomScalar description',
+  serialize: (value) => {
+    /* Implement logic to turn the returned value from resolvers to a value that can be sent to clients */
+  },
+  parseValue: (value) => {
+    /* Implement logic to parse input that was sent to the server as variables */
+  },
+  parseLiteral: (ast) => {
+    /* Implement logic to parse input that was sent to the server as literal values (string, number, or boolean) */
+  },
+});

--- a/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type/codegen.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type/codegen.ts
@@ -1,0 +1,22 @@
+import type { CodegenConfig } from '@graphql-codegen/cli';
+import { defineConfig } from '@eddeee888/gcg-typescript-resolver-files';
+
+const config: CodegenConfig = {
+  hooks: {
+    afterAllFileWrite: ['prettier --write'],
+  },
+  generates: {
+    'packages/typescript-resolver-files-e2e/src/test-schema-federated-extended-object-type/schema':
+      defineConfig(
+        {},
+        {
+          schema: [
+            'packages/typescript-resolver-files-e2e/src/test-schema-federated-extended-object-type/**/*.graphqls',
+            'packages/typescript-resolver-files-e2e/src/test-schema-federated-extended-object-type/**/*.graphqls.ts',
+          ],
+        }
+      ),
+  },
+};
+
+export default config;

--- a/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type/resolvers.generated.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type/resolvers.generated.ts
@@ -1,0 +1,49 @@
+/* This file was automatically generated. DO NOT UPDATE MANUALLY. */
+import type { Resolvers } from './types.generated';
+import { ForeignType as topic_ForeignType } from './topic/resolvers/ForeignType';
+import { ForeignType as user_ForeignType } from './user/resolvers/ForeignType';
+import { topicCreate as Mutation_topicCreate } from './topic/resolvers/Mutation/topicCreate';
+import { topicEdit as Mutation_topicEdit } from './topic/resolvers/Mutation/topicEdit';
+import { PaginationResult } from './base/resolvers/PaginationResult';
+import { PayloadError } from './base/resolvers/PayloadError';
+import { Profile } from './user/resolvers/Profile';
+import { me as Query_me } from './user/resolvers/Query/me';
+import { topicById as Query_topicById } from './topic/resolvers/Query/topicById';
+import { topicsCreatedByUser as Query_topicsCreatedByUser } from './topic/resolvers/Query/topicsCreatedByUser';
+import { userByAccountName as Query_userByAccountName } from './user/resolvers/Query/userByAccountName';
+import { SomeRandomScalar } from './base/resolvers/SomeRandomScalar';
+import { profileChanges as Subscription_profileChanges } from './user/resolvers/Subscription/profileChanges';
+import { Topic } from './topic/resolvers/Topic';
+import { TopicByIdResult } from './topic/resolvers/TopicByIdResult';
+import { TopicCreateResult } from './topic/resolvers/TopicCreateResult';
+import { TopicEditResult } from './topic/resolvers/TopicEditResult';
+import { TopicsCreatedByUserResult } from './topic/resolvers/TopicsCreatedByUserResult';
+import { User } from './user/resolvers/User';
+import { UserResult } from './user/resolvers/UserResult';
+import { DateTimeResolver } from 'graphql-scalars';
+export const resolvers: Resolvers = {
+  Query: {
+    me: Query_me,
+    topicById: Query_topicById,
+    topicsCreatedByUser: Query_topicsCreatedByUser,
+    userByAccountName: Query_userByAccountName,
+  },
+  Mutation: {
+    topicCreate: Mutation_topicCreate,
+    topicEdit: Mutation_topicEdit,
+  },
+  Subscription: { profileChanges: Subscription_profileChanges },
+  ForeignType: { ...topic_ForeignType, ...user_ForeignType },
+  PaginationResult: PaginationResult,
+  PayloadError: PayloadError,
+  Profile: Profile,
+  SomeRandomScalar: SomeRandomScalar,
+  Topic: Topic,
+  TopicByIdResult: TopicByIdResult,
+  TopicCreateResult: TopicCreateResult,
+  TopicEditResult: TopicEditResult,
+  TopicsCreatedByUserResult: TopicsCreatedByUserResult,
+  User: User,
+  UserResult: UserResult,
+  DateTime: DateTimeResolver,
+};

--- a/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type/schema/base/base.graphqls
+++ b/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type/schema/base/base.graphqls
@@ -1,0 +1,32 @@
+type Query
+type Mutation
+type Subscription
+
+interface Error {
+  error: ErrorType!
+}
+
+type PayloadError implements Error {
+  error: ErrorType!
+}
+
+enum ErrorType {
+  NOT_FOUND
+  INPUT_VALIDATION_ERROR
+  FORBIDDEN_ERROR
+  UNEXPECTED_ERROR
+}
+
+input PaginationInput {
+  recordsPerPage: Int
+  page: Int
+}
+
+type PaginationResult {
+  currentPage: Int!
+  recordsPerPage: Int!
+  totalPageCount: Int!
+}
+
+scalar DateTime
+scalar SomeRandomScalar

--- a/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type/schema/topic/topic.graphqls
+++ b/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type/schema/topic/topic.graphqls
@@ -1,0 +1,63 @@
+extend type Query {
+  topicById(id: ID!): TopicByIdPayload!
+  topicsCreatedByUser(
+    input: TopicsCreatedByUserInput!
+  ): TopicsCreatedByUserPayload!
+}
+
+extend type Mutation {
+  topicCreate(input: TopicCreateInput!): TopicCreatePayload!
+  topicEdit(input: TopicEditInput!): TopicEditPayload!
+}
+
+type Topic {
+  id: ID!
+  name: String!
+  url: String
+  creator: User!
+  createdAt: DateTime!
+}
+
+type ForeignType @key(fields: "id") {
+  id: ID!
+  topics: [Topic!]!
+}
+
+type TopicByIdResult {
+  result: Topic
+}
+
+union TopicByIdPayload = TopicByIdResult | PayloadError
+
+input TopicsCreatedByUserInput {
+  userId: ID!
+}
+
+type TopicsCreatedByUserResult {
+  result: [Topic!]!
+}
+
+union TopicsCreatedByUserPayload = TopicsCreatedByUserResult | PayloadError
+
+input TopicCreateInput {
+  name: String!
+  url: String
+}
+
+type TopicCreateResult {
+  result: Topic!
+}
+
+union TopicCreatePayload = TopicCreateResult | PayloadError
+
+input TopicEditInput {
+  id: ID!
+  name: String!
+  url: String
+}
+
+type TopicEditResult {
+  result: Topic!
+}
+
+union TopicEditPayload = TopicEditResult | PayloadError

--- a/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type/schema/topic/topic.mappers.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type/schema/topic/topic.mappers.ts
@@ -1,0 +1,7 @@
+export type TopicMapper = {
+  id: string;
+  name: string;
+  url: string | null;
+  creatorUserId: string;
+  createdAt: Date;
+};

--- a/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type/schema/user/profile.graphqls
+++ b/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type/schema/user/profile.graphqls
@@ -1,0 +1,8 @@
+extend type Subscription {
+  profileChanges: Profile!
+}
+
+type Profile {
+  id: ID!
+  user: User!
+}

--- a/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type/schema/user/user.graphqls.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type/schema/user/user.graphqls.ts
@@ -1,0 +1,29 @@
+import gql from 'graphql-tag';
+
+export const userTypeDefs = gql`
+  extend type Query {
+    me: UserPayload!
+    userByAccountName(accountName: String!): UserPayload!
+  }
+
+  type User {
+    id: ID!
+    name: String
+    accountName: String!
+    accountWebsite: String
+    accountTwitter: String
+    accountGitHub: String
+    accountLinkedIn: String
+    avatar: String
+  }
+
+  extend type ForeignType {
+    users: [User!]!
+  }
+
+  type UserResult {
+    result: User
+  }
+
+  union UserPayload = UserResult | PayloadError
+`;

--- a/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type/topic/resolvers/ForeignType.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type/topic/resolvers/ForeignType.ts
@@ -1,0 +1,7 @@
+import type { ForeignTypeResolvers } from './../../types.generated';
+export const ForeignType: Pick<
+  ForeignTypeResolvers,
+  'id' | 'topics' | '__resolveReference'
+> = {
+  /* Implement ForeignType resolver logic here */
+};

--- a/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type/topic/resolvers/Mutation/topicCreate.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type/topic/resolvers/Mutation/topicCreate.ts
@@ -1,0 +1,6 @@
+import type { MutationResolvers } from './../../../types.generated';
+export const topicCreate: NonNullable<
+  MutationResolvers['topicCreate']
+> = async (_parent, _arg, _ctx) => {
+  /* Implement Mutation.topicCreate resolver logic here */
+};

--- a/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type/topic/resolvers/Mutation/topicEdit.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type/topic/resolvers/Mutation/topicEdit.ts
@@ -1,0 +1,8 @@
+import type { MutationResolvers } from './../../../types.generated';
+export const topicEdit: NonNullable<MutationResolvers['topicEdit']> = async (
+  _parent,
+  _arg,
+  _ctx
+) => {
+  /* Implement Mutation.topicEdit resolver logic here */
+};

--- a/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type/topic/resolvers/Query/topicById.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type/topic/resolvers/Query/topicById.ts
@@ -1,0 +1,8 @@
+import type { QueryResolvers } from './../../../types.generated';
+export const topicById: NonNullable<QueryResolvers['topicById']> = async (
+  _parent,
+  _arg,
+  _ctx
+) => {
+  /* Implement Query.topicById resolver logic here */
+};

--- a/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type/topic/resolvers/Query/topicsCreatedByUser.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type/topic/resolvers/Query/topicsCreatedByUser.ts
@@ -1,0 +1,6 @@
+import type { QueryResolvers } from './../../../types.generated';
+export const topicsCreatedByUser: NonNullable<
+  QueryResolvers['topicsCreatedByUser']
+> = async (_parent, _arg, _ctx) => {
+  /* Implement Query.topicsCreatedByUser resolver logic here */
+};

--- a/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type/topic/resolvers/Topic.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type/topic/resolvers/Topic.ts
@@ -1,0 +1,7 @@
+import type { TopicResolvers } from './../../types.generated';
+export const Topic: TopicResolvers = {
+  /* Implement Topic resolver logic here */
+  creator: () => {
+    /* Topic.creator resolver is required because Topic.creator exists but TopicMapper.creator does not */
+  },
+};

--- a/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type/topic/resolvers/TopicByIdResult.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type/topic/resolvers/TopicByIdResult.ts
@@ -1,0 +1,4 @@
+import type { TopicByIdResultResolvers } from './../../types.generated';
+export const TopicByIdResult: TopicByIdResultResolvers = {
+  /* Implement TopicByIdResult resolver logic here */
+};

--- a/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type/topic/resolvers/TopicCreateResult.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type/topic/resolvers/TopicCreateResult.ts
@@ -1,0 +1,4 @@
+import type { TopicCreateResultResolvers } from './../../types.generated';
+export const TopicCreateResult: TopicCreateResultResolvers = {
+  /* Implement TopicCreateResult resolver logic here */
+};

--- a/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type/topic/resolvers/TopicEditResult.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type/topic/resolvers/TopicEditResult.ts
@@ -1,0 +1,4 @@
+import type { TopicEditResultResolvers } from './../../types.generated';
+export const TopicEditResult: TopicEditResultResolvers = {
+  /* Implement TopicEditResult resolver logic here */
+};

--- a/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type/topic/resolvers/TopicsCreatedByUserResult.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type/topic/resolvers/TopicsCreatedByUserResult.ts
@@ -1,0 +1,4 @@
+import type { TopicsCreatedByUserResultResolvers } from './../../types.generated';
+export const TopicsCreatedByUserResult: TopicsCreatedByUserResultResolvers = {
+  /* Implement TopicsCreatedByUserResult resolver logic here */
+};

--- a/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type/typeDefs.generated.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type/typeDefs.generated.ts
@@ -1,0 +1,1575 @@
+import type { DocumentNode } from 'graphql';
+export const typeDefs = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'ObjectTypeDefinition',
+      name: { kind: 'Name', value: 'Query', loc: { start: 5, end: 10 } },
+      interfaces: [],
+      directives: [],
+      fields: [],
+      loc: { start: 0, end: 10 },
+    },
+    {
+      kind: 'ObjectTypeDefinition',
+      name: { kind: 'Name', value: 'Mutation', loc: { start: 17, end: 25 } },
+      interfaces: [],
+      directives: [],
+      fields: [],
+      loc: { start: 12, end: 25 },
+    },
+    {
+      kind: 'ObjectTypeDefinition',
+      name: {
+        kind: 'Name',
+        value: 'Subscription',
+        loc: { start: 32, end: 44 },
+      },
+      interfaces: [],
+      directives: [],
+      fields: [],
+      loc: { start: 27, end: 44 },
+    },
+    {
+      kind: 'InterfaceTypeDefinition',
+      name: { kind: 'Name', value: 'Error', loc: { start: 56, end: 61 } },
+      interfaces: [],
+      directives: [],
+      fields: [
+        {
+          kind: 'FieldDefinition',
+          name: { kind: 'Name', value: 'error', loc: { start: 66, end: 71 } },
+          arguments: [],
+          type: {
+            kind: 'NonNullType',
+            type: {
+              kind: 'NamedType',
+              name: {
+                kind: 'Name',
+                value: 'ErrorType',
+                loc: { start: 73, end: 82 },
+              },
+              loc: { start: 73, end: 82 },
+            },
+            loc: { start: 73, end: 83 },
+          },
+          directives: [],
+          loc: { start: 66, end: 83 },
+        },
+      ],
+      loc: { start: 46, end: 85 },
+    },
+    {
+      kind: 'ObjectTypeDefinition',
+      name: {
+        kind: 'Name',
+        value: 'PayloadError',
+        loc: { start: 92, end: 104 },
+      },
+      interfaces: [
+        {
+          kind: 'NamedType',
+          name: { kind: 'Name', value: 'Error', loc: { start: 116, end: 121 } },
+          loc: { start: 116, end: 121 },
+        },
+      ],
+      directives: [],
+      fields: [
+        {
+          kind: 'FieldDefinition',
+          name: { kind: 'Name', value: 'error', loc: { start: 126, end: 131 } },
+          arguments: [],
+          type: {
+            kind: 'NonNullType',
+            type: {
+              kind: 'NamedType',
+              name: {
+                kind: 'Name',
+                value: 'ErrorType',
+                loc: { start: 133, end: 142 },
+              },
+              loc: { start: 133, end: 142 },
+            },
+            loc: { start: 133, end: 143 },
+          },
+          directives: [],
+          loc: { start: 126, end: 143 },
+        },
+      ],
+      loc: { start: 87, end: 145 },
+    },
+    {
+      kind: 'EnumTypeDefinition',
+      name: { kind: 'Name', value: 'ErrorType', loc: { start: 152, end: 161 } },
+      directives: [],
+      values: [
+        {
+          kind: 'EnumValueDefinition',
+          name: {
+            kind: 'Name',
+            value: 'NOT_FOUND',
+            loc: { start: 166, end: 175 },
+          },
+          directives: [],
+          loc: { start: 166, end: 175 },
+        },
+        {
+          kind: 'EnumValueDefinition',
+          name: {
+            kind: 'Name',
+            value: 'INPUT_VALIDATION_ERROR',
+            loc: { start: 178, end: 200 },
+          },
+          directives: [],
+          loc: { start: 178, end: 200 },
+        },
+        {
+          kind: 'EnumValueDefinition',
+          name: {
+            kind: 'Name',
+            value: 'FORBIDDEN_ERROR',
+            loc: { start: 203, end: 218 },
+          },
+          directives: [],
+          loc: { start: 203, end: 218 },
+        },
+        {
+          kind: 'EnumValueDefinition',
+          name: {
+            kind: 'Name',
+            value: 'UNEXPECTED_ERROR',
+            loc: { start: 221, end: 237 },
+          },
+          directives: [],
+          loc: { start: 221, end: 237 },
+        },
+      ],
+      loc: { start: 147, end: 239 },
+    },
+    {
+      kind: 'InputObjectTypeDefinition',
+      name: {
+        kind: 'Name',
+        value: 'PaginationInput',
+        loc: { start: 247, end: 262 },
+      },
+      directives: [],
+      fields: [
+        {
+          kind: 'InputValueDefinition',
+          name: {
+            kind: 'Name',
+            value: 'recordsPerPage',
+            loc: { start: 267, end: 281 },
+          },
+          type: {
+            kind: 'NamedType',
+            name: { kind: 'Name', value: 'Int', loc: { start: 283, end: 286 } },
+            loc: { start: 283, end: 286 },
+          },
+          directives: [],
+          loc: { start: 267, end: 286 },
+        },
+        {
+          kind: 'InputValueDefinition',
+          name: { kind: 'Name', value: 'page', loc: { start: 289, end: 293 } },
+          type: {
+            kind: 'NamedType',
+            name: { kind: 'Name', value: 'Int', loc: { start: 295, end: 298 } },
+            loc: { start: 295, end: 298 },
+          },
+          directives: [],
+          loc: { start: 289, end: 298 },
+        },
+      ],
+      loc: { start: 241, end: 300 },
+    },
+    {
+      kind: 'ObjectTypeDefinition',
+      name: {
+        kind: 'Name',
+        value: 'PaginationResult',
+        loc: { start: 307, end: 323 },
+      },
+      interfaces: [],
+      directives: [],
+      fields: [
+        {
+          kind: 'FieldDefinition',
+          name: {
+            kind: 'Name',
+            value: 'currentPage',
+            loc: { start: 328, end: 339 },
+          },
+          arguments: [],
+          type: {
+            kind: 'NonNullType',
+            type: {
+              kind: 'NamedType',
+              name: {
+                kind: 'Name',
+                value: 'Int',
+                loc: { start: 341, end: 344 },
+              },
+              loc: { start: 341, end: 344 },
+            },
+            loc: { start: 341, end: 345 },
+          },
+          directives: [],
+          loc: { start: 328, end: 345 },
+        },
+        {
+          kind: 'FieldDefinition',
+          name: {
+            kind: 'Name',
+            value: 'recordsPerPage',
+            loc: { start: 348, end: 362 },
+          },
+          arguments: [],
+          type: {
+            kind: 'NonNullType',
+            type: {
+              kind: 'NamedType',
+              name: {
+                kind: 'Name',
+                value: 'Int',
+                loc: { start: 364, end: 367 },
+              },
+              loc: { start: 364, end: 367 },
+            },
+            loc: { start: 364, end: 368 },
+          },
+          directives: [],
+          loc: { start: 348, end: 368 },
+        },
+        {
+          kind: 'FieldDefinition',
+          name: {
+            kind: 'Name',
+            value: 'totalPageCount',
+            loc: { start: 371, end: 385 },
+          },
+          arguments: [],
+          type: {
+            kind: 'NonNullType',
+            type: {
+              kind: 'NamedType',
+              name: {
+                kind: 'Name',
+                value: 'Int',
+                loc: { start: 387, end: 390 },
+              },
+              loc: { start: 387, end: 390 },
+            },
+            loc: { start: 387, end: 391 },
+          },
+          directives: [],
+          loc: { start: 371, end: 391 },
+        },
+      ],
+      loc: { start: 302, end: 393 },
+    },
+    {
+      kind: 'ScalarTypeDefinition',
+      name: { kind: 'Name', value: 'DateTime', loc: { start: 402, end: 410 } },
+      directives: [],
+      loc: { start: 395, end: 410 },
+    },
+    {
+      kind: 'ScalarTypeDefinition',
+      name: {
+        kind: 'Name',
+        value: 'SomeRandomScalar',
+        loc: { start: 419, end: 435 },
+      },
+      directives: [],
+      loc: { start: 412, end: 435 },
+    },
+    {
+      kind: 'ObjectTypeExtension',
+      name: { kind: 'Name', value: 'Query', loc: { start: 448, end: 453 } },
+      interfaces: [],
+      directives: [],
+      fields: [
+        {
+          kind: 'FieldDefinition',
+          name: {
+            kind: 'Name',
+            value: 'topicById',
+            loc: { start: 458, end: 467 },
+          },
+          arguments: [
+            {
+              kind: 'InputValueDefinition',
+              name: {
+                kind: 'Name',
+                value: 'id',
+                loc: { start: 468, end: 470 },
+              },
+              type: {
+                kind: 'NonNullType',
+                type: {
+                  kind: 'NamedType',
+                  name: {
+                    kind: 'Name',
+                    value: 'ID',
+                    loc: { start: 472, end: 474 },
+                  },
+                  loc: { start: 472, end: 474 },
+                },
+                loc: { start: 472, end: 475 },
+              },
+              directives: [],
+              loc: { start: 468, end: 475 },
+            },
+          ],
+          type: {
+            kind: 'NonNullType',
+            type: {
+              kind: 'NamedType',
+              name: {
+                kind: 'Name',
+                value: 'TopicByIdPayload',
+                loc: { start: 478, end: 494 },
+              },
+              loc: { start: 478, end: 494 },
+            },
+            loc: { start: 478, end: 495 },
+          },
+          directives: [],
+          loc: { start: 458, end: 495 },
+        },
+        {
+          kind: 'FieldDefinition',
+          name: {
+            kind: 'Name',
+            value: 'topicsCreatedByUser',
+            loc: { start: 498, end: 517 },
+          },
+          arguments: [
+            {
+              kind: 'InputValueDefinition',
+              name: {
+                kind: 'Name',
+                value: 'input',
+                loc: { start: 518, end: 523 },
+              },
+              type: {
+                kind: 'NonNullType',
+                type: {
+                  kind: 'NamedType',
+                  name: {
+                    kind: 'Name',
+                    value: 'TopicsCreatedByUserInput',
+                    loc: { start: 525, end: 549 },
+                  },
+                  loc: { start: 525, end: 549 },
+                },
+                loc: { start: 525, end: 550 },
+              },
+              directives: [],
+              loc: { start: 518, end: 550 },
+            },
+          ],
+          type: {
+            kind: 'NonNullType',
+            type: {
+              kind: 'NamedType',
+              name: {
+                kind: 'Name',
+                value: 'TopicsCreatedByUserPayload',
+                loc: { start: 553, end: 579 },
+              },
+              loc: { start: 553, end: 579 },
+            },
+            loc: { start: 553, end: 580 },
+          },
+          directives: [],
+          loc: { start: 498, end: 580 },
+        },
+      ],
+      loc: { start: 436, end: 582 },
+    },
+    {
+      kind: 'ObjectTypeExtension',
+      name: { kind: 'Name', value: 'Mutation', loc: { start: 596, end: 604 } },
+      interfaces: [],
+      directives: [],
+      fields: [
+        {
+          kind: 'FieldDefinition',
+          name: {
+            kind: 'Name',
+            value: 'topicCreate',
+            loc: { start: 609, end: 620 },
+          },
+          arguments: [
+            {
+              kind: 'InputValueDefinition',
+              name: {
+                kind: 'Name',
+                value: 'input',
+                loc: { start: 621, end: 626 },
+              },
+              type: {
+                kind: 'NonNullType',
+                type: {
+                  kind: 'NamedType',
+                  name: {
+                    kind: 'Name',
+                    value: 'TopicCreateInput',
+                    loc: { start: 628, end: 644 },
+                  },
+                  loc: { start: 628, end: 644 },
+                },
+                loc: { start: 628, end: 645 },
+              },
+              directives: [],
+              loc: { start: 621, end: 645 },
+            },
+          ],
+          type: {
+            kind: 'NonNullType',
+            type: {
+              kind: 'NamedType',
+              name: {
+                kind: 'Name',
+                value: 'TopicCreatePayload',
+                loc: { start: 648, end: 666 },
+              },
+              loc: { start: 648, end: 666 },
+            },
+            loc: { start: 648, end: 667 },
+          },
+          directives: [],
+          loc: { start: 609, end: 667 },
+        },
+        {
+          kind: 'FieldDefinition',
+          name: {
+            kind: 'Name',
+            value: 'topicEdit',
+            loc: { start: 670, end: 679 },
+          },
+          arguments: [
+            {
+              kind: 'InputValueDefinition',
+              name: {
+                kind: 'Name',
+                value: 'input',
+                loc: { start: 680, end: 685 },
+              },
+              type: {
+                kind: 'NonNullType',
+                type: {
+                  kind: 'NamedType',
+                  name: {
+                    kind: 'Name',
+                    value: 'TopicEditInput',
+                    loc: { start: 687, end: 701 },
+                  },
+                  loc: { start: 687, end: 701 },
+                },
+                loc: { start: 687, end: 702 },
+              },
+              directives: [],
+              loc: { start: 680, end: 702 },
+            },
+          ],
+          type: {
+            kind: 'NonNullType',
+            type: {
+              kind: 'NamedType',
+              name: {
+                kind: 'Name',
+                value: 'TopicEditPayload',
+                loc: { start: 705, end: 721 },
+              },
+              loc: { start: 705, end: 721 },
+            },
+            loc: { start: 705, end: 722 },
+          },
+          directives: [],
+          loc: { start: 670, end: 722 },
+        },
+      ],
+      loc: { start: 584, end: 724 },
+    },
+    {
+      kind: 'ObjectTypeDefinition',
+      name: { kind: 'Name', value: 'Topic', loc: { start: 731, end: 736 } },
+      interfaces: [],
+      directives: [],
+      fields: [
+        {
+          kind: 'FieldDefinition',
+          name: { kind: 'Name', value: 'id', loc: { start: 741, end: 743 } },
+          arguments: [],
+          type: {
+            kind: 'NonNullType',
+            type: {
+              kind: 'NamedType',
+              name: {
+                kind: 'Name',
+                value: 'ID',
+                loc: { start: 745, end: 747 },
+              },
+              loc: { start: 745, end: 747 },
+            },
+            loc: { start: 745, end: 748 },
+          },
+          directives: [],
+          loc: { start: 741, end: 748 },
+        },
+        {
+          kind: 'FieldDefinition',
+          name: { kind: 'Name', value: 'name', loc: { start: 751, end: 755 } },
+          arguments: [],
+          type: {
+            kind: 'NonNullType',
+            type: {
+              kind: 'NamedType',
+              name: {
+                kind: 'Name',
+                value: 'String',
+                loc: { start: 757, end: 763 },
+              },
+              loc: { start: 757, end: 763 },
+            },
+            loc: { start: 757, end: 764 },
+          },
+          directives: [],
+          loc: { start: 751, end: 764 },
+        },
+        {
+          kind: 'FieldDefinition',
+          name: { kind: 'Name', value: 'url', loc: { start: 767, end: 770 } },
+          arguments: [],
+          type: {
+            kind: 'NamedType',
+            name: {
+              kind: 'Name',
+              value: 'String',
+              loc: { start: 772, end: 778 },
+            },
+            loc: { start: 772, end: 778 },
+          },
+          directives: [],
+          loc: { start: 767, end: 778 },
+        },
+        {
+          kind: 'FieldDefinition',
+          name: {
+            kind: 'Name',
+            value: 'creator',
+            loc: { start: 781, end: 788 },
+          },
+          arguments: [],
+          type: {
+            kind: 'NonNullType',
+            type: {
+              kind: 'NamedType',
+              name: {
+                kind: 'Name',
+                value: 'User',
+                loc: { start: 790, end: 794 },
+              },
+              loc: { start: 790, end: 794 },
+            },
+            loc: { start: 790, end: 795 },
+          },
+          directives: [],
+          loc: { start: 781, end: 795 },
+        },
+        {
+          kind: 'FieldDefinition',
+          name: {
+            kind: 'Name',
+            value: 'createdAt',
+            loc: { start: 798, end: 807 },
+          },
+          arguments: [],
+          type: {
+            kind: 'NonNullType',
+            type: {
+              kind: 'NamedType',
+              name: {
+                kind: 'Name',
+                value: 'DateTime',
+                loc: { start: 809, end: 817 },
+              },
+              loc: { start: 809, end: 817 },
+            },
+            loc: { start: 809, end: 818 },
+          },
+          directives: [],
+          loc: { start: 798, end: 818 },
+        },
+      ],
+      loc: { start: 726, end: 820 },
+    },
+    {
+      kind: 'ObjectTypeDefinition',
+      name: {
+        kind: 'Name',
+        value: 'ForeignType',
+        loc: { start: 827, end: 838 },
+      },
+      interfaces: [],
+      directives: [
+        {
+          kind: 'Directive',
+          name: { kind: 'Name', value: 'key', loc: { start: 840, end: 843 } },
+          arguments: [
+            {
+              kind: 'Argument',
+              name: {
+                kind: 'Name',
+                value: 'fields',
+                loc: { start: 844, end: 850 },
+              },
+              value: {
+                kind: 'StringValue',
+                value: 'id',
+                block: false,
+                loc: { start: 852, end: 856 },
+              },
+              loc: { start: 844, end: 856 },
+            },
+          ],
+          loc: { start: 839, end: 857 },
+        },
+      ],
+      fields: [
+        {
+          kind: 'FieldDefinition',
+          name: { kind: 'Name', value: 'id', loc: { start: 862, end: 864 } },
+          arguments: [],
+          type: {
+            kind: 'NonNullType',
+            type: {
+              kind: 'NamedType',
+              name: {
+                kind: 'Name',
+                value: 'ID',
+                loc: { start: 866, end: 868 },
+              },
+              loc: { start: 866, end: 868 },
+            },
+            loc: { start: 866, end: 869 },
+          },
+          directives: [],
+          loc: { start: 862, end: 869 },
+        },
+        {
+          kind: 'FieldDefinition',
+          name: {
+            kind: 'Name',
+            value: 'topics',
+            loc: { start: 872, end: 878 },
+          },
+          arguments: [],
+          type: {
+            kind: 'NonNullType',
+            type: {
+              kind: 'ListType',
+              type: {
+                kind: 'NonNullType',
+                type: {
+                  kind: 'NamedType',
+                  name: {
+                    kind: 'Name',
+                    value: 'Topic',
+                    loc: { start: 881, end: 886 },
+                  },
+                  loc: { start: 881, end: 886 },
+                },
+                loc: { start: 881, end: 887 },
+              },
+              loc: { start: 880, end: 888 },
+            },
+            loc: { start: 880, end: 889 },
+          },
+          directives: [],
+          loc: { start: 872, end: 889 },
+        },
+      ],
+      loc: { start: 822, end: 891 },
+    },
+    {
+      kind: 'ObjectTypeDefinition',
+      name: {
+        kind: 'Name',
+        value: 'TopicByIdResult',
+        loc: { start: 898, end: 913 },
+      },
+      interfaces: [],
+      directives: [],
+      fields: [
+        {
+          kind: 'FieldDefinition',
+          name: {
+            kind: 'Name',
+            value: 'result',
+            loc: { start: 918, end: 924 },
+          },
+          arguments: [],
+          type: {
+            kind: 'NamedType',
+            name: {
+              kind: 'Name',
+              value: 'Topic',
+              loc: { start: 926, end: 931 },
+            },
+            loc: { start: 926, end: 931 },
+          },
+          directives: [],
+          loc: { start: 918, end: 931 },
+        },
+      ],
+      loc: { start: 893, end: 933 },
+    },
+    {
+      kind: 'UnionTypeDefinition',
+      name: {
+        kind: 'Name',
+        value: 'TopicByIdPayload',
+        loc: { start: 941, end: 957 },
+      },
+      directives: [],
+      types: [
+        {
+          kind: 'NamedType',
+          name: {
+            kind: 'Name',
+            value: 'TopicByIdResult',
+            loc: { start: 960, end: 975 },
+          },
+          loc: { start: 960, end: 975 },
+        },
+        {
+          kind: 'NamedType',
+          name: {
+            kind: 'Name',
+            value: 'PayloadError',
+            loc: { start: 978, end: 990 },
+          },
+          loc: { start: 978, end: 990 },
+        },
+      ],
+      loc: { start: 935, end: 990 },
+    },
+    {
+      kind: 'InputObjectTypeDefinition',
+      name: {
+        kind: 'Name',
+        value: 'TopicsCreatedByUserInput',
+        loc: { start: 998, end: 1022 },
+      },
+      directives: [],
+      fields: [
+        {
+          kind: 'InputValueDefinition',
+          name: {
+            kind: 'Name',
+            value: 'userId',
+            loc: { start: 1027, end: 1033 },
+          },
+          type: {
+            kind: 'NonNullType',
+            type: {
+              kind: 'NamedType',
+              name: {
+                kind: 'Name',
+                value: 'ID',
+                loc: { start: 1035, end: 1037 },
+              },
+              loc: { start: 1035, end: 1037 },
+            },
+            loc: { start: 1035, end: 1038 },
+          },
+          directives: [],
+          loc: { start: 1027, end: 1038 },
+        },
+      ],
+      loc: { start: 992, end: 1040 },
+    },
+    {
+      kind: 'ObjectTypeDefinition',
+      name: {
+        kind: 'Name',
+        value: 'TopicsCreatedByUserResult',
+        loc: { start: 1047, end: 1072 },
+      },
+      interfaces: [],
+      directives: [],
+      fields: [
+        {
+          kind: 'FieldDefinition',
+          name: {
+            kind: 'Name',
+            value: 'result',
+            loc: { start: 1077, end: 1083 },
+          },
+          arguments: [],
+          type: {
+            kind: 'NonNullType',
+            type: {
+              kind: 'ListType',
+              type: {
+                kind: 'NonNullType',
+                type: {
+                  kind: 'NamedType',
+                  name: {
+                    kind: 'Name',
+                    value: 'Topic',
+                    loc: { start: 1086, end: 1091 },
+                  },
+                  loc: { start: 1086, end: 1091 },
+                },
+                loc: { start: 1086, end: 1092 },
+              },
+              loc: { start: 1085, end: 1093 },
+            },
+            loc: { start: 1085, end: 1094 },
+          },
+          directives: [],
+          loc: { start: 1077, end: 1094 },
+        },
+      ],
+      loc: { start: 1042, end: 1096 },
+    },
+    {
+      kind: 'UnionTypeDefinition',
+      name: {
+        kind: 'Name',
+        value: 'TopicsCreatedByUserPayload',
+        loc: { start: 1104, end: 1130 },
+      },
+      directives: [],
+      types: [
+        {
+          kind: 'NamedType',
+          name: {
+            kind: 'Name',
+            value: 'TopicsCreatedByUserResult',
+            loc: { start: 1133, end: 1158 },
+          },
+          loc: { start: 1133, end: 1158 },
+        },
+        {
+          kind: 'NamedType',
+          name: {
+            kind: 'Name',
+            value: 'PayloadError',
+            loc: { start: 1161, end: 1173 },
+          },
+          loc: { start: 1161, end: 1173 },
+        },
+      ],
+      loc: { start: 1098, end: 1173 },
+    },
+    {
+      kind: 'InputObjectTypeDefinition',
+      name: {
+        kind: 'Name',
+        value: 'TopicCreateInput',
+        loc: { start: 1181, end: 1197 },
+      },
+      directives: [],
+      fields: [
+        {
+          kind: 'InputValueDefinition',
+          name: {
+            kind: 'Name',
+            value: 'name',
+            loc: { start: 1202, end: 1206 },
+          },
+          type: {
+            kind: 'NonNullType',
+            type: {
+              kind: 'NamedType',
+              name: {
+                kind: 'Name',
+                value: 'String',
+                loc: { start: 1208, end: 1214 },
+              },
+              loc: { start: 1208, end: 1214 },
+            },
+            loc: { start: 1208, end: 1215 },
+          },
+          directives: [],
+          loc: { start: 1202, end: 1215 },
+        },
+        {
+          kind: 'InputValueDefinition',
+          name: { kind: 'Name', value: 'url', loc: { start: 1218, end: 1221 } },
+          type: {
+            kind: 'NamedType',
+            name: {
+              kind: 'Name',
+              value: 'String',
+              loc: { start: 1223, end: 1229 },
+            },
+            loc: { start: 1223, end: 1229 },
+          },
+          directives: [],
+          loc: { start: 1218, end: 1229 },
+        },
+      ],
+      loc: { start: 1175, end: 1231 },
+    },
+    {
+      kind: 'ObjectTypeDefinition',
+      name: {
+        kind: 'Name',
+        value: 'TopicCreateResult',
+        loc: { start: 1238, end: 1255 },
+      },
+      interfaces: [],
+      directives: [],
+      fields: [
+        {
+          kind: 'FieldDefinition',
+          name: {
+            kind: 'Name',
+            value: 'result',
+            loc: { start: 1260, end: 1266 },
+          },
+          arguments: [],
+          type: {
+            kind: 'NonNullType',
+            type: {
+              kind: 'NamedType',
+              name: {
+                kind: 'Name',
+                value: 'Topic',
+                loc: { start: 1268, end: 1273 },
+              },
+              loc: { start: 1268, end: 1273 },
+            },
+            loc: { start: 1268, end: 1274 },
+          },
+          directives: [],
+          loc: { start: 1260, end: 1274 },
+        },
+      ],
+      loc: { start: 1233, end: 1276 },
+    },
+    {
+      kind: 'UnionTypeDefinition',
+      name: {
+        kind: 'Name',
+        value: 'TopicCreatePayload',
+        loc: { start: 1284, end: 1302 },
+      },
+      directives: [],
+      types: [
+        {
+          kind: 'NamedType',
+          name: {
+            kind: 'Name',
+            value: 'TopicCreateResult',
+            loc: { start: 1305, end: 1322 },
+          },
+          loc: { start: 1305, end: 1322 },
+        },
+        {
+          kind: 'NamedType',
+          name: {
+            kind: 'Name',
+            value: 'PayloadError',
+            loc: { start: 1325, end: 1337 },
+          },
+          loc: { start: 1325, end: 1337 },
+        },
+      ],
+      loc: { start: 1278, end: 1337 },
+    },
+    {
+      kind: 'InputObjectTypeDefinition',
+      name: {
+        kind: 'Name',
+        value: 'TopicEditInput',
+        loc: { start: 1345, end: 1359 },
+      },
+      directives: [],
+      fields: [
+        {
+          kind: 'InputValueDefinition',
+          name: { kind: 'Name', value: 'id', loc: { start: 1364, end: 1366 } },
+          type: {
+            kind: 'NonNullType',
+            type: {
+              kind: 'NamedType',
+              name: {
+                kind: 'Name',
+                value: 'ID',
+                loc: { start: 1368, end: 1370 },
+              },
+              loc: { start: 1368, end: 1370 },
+            },
+            loc: { start: 1368, end: 1371 },
+          },
+          directives: [],
+          loc: { start: 1364, end: 1371 },
+        },
+        {
+          kind: 'InputValueDefinition',
+          name: {
+            kind: 'Name',
+            value: 'name',
+            loc: { start: 1374, end: 1378 },
+          },
+          type: {
+            kind: 'NonNullType',
+            type: {
+              kind: 'NamedType',
+              name: {
+                kind: 'Name',
+                value: 'String',
+                loc: { start: 1380, end: 1386 },
+              },
+              loc: { start: 1380, end: 1386 },
+            },
+            loc: { start: 1380, end: 1387 },
+          },
+          directives: [],
+          loc: { start: 1374, end: 1387 },
+        },
+        {
+          kind: 'InputValueDefinition',
+          name: { kind: 'Name', value: 'url', loc: { start: 1390, end: 1393 } },
+          type: {
+            kind: 'NamedType',
+            name: {
+              kind: 'Name',
+              value: 'String',
+              loc: { start: 1395, end: 1401 },
+            },
+            loc: { start: 1395, end: 1401 },
+          },
+          directives: [],
+          loc: { start: 1390, end: 1401 },
+        },
+      ],
+      loc: { start: 1339, end: 1403 },
+    },
+    {
+      kind: 'ObjectTypeDefinition',
+      name: {
+        kind: 'Name',
+        value: 'TopicEditResult',
+        loc: { start: 1410, end: 1425 },
+      },
+      interfaces: [],
+      directives: [],
+      fields: [
+        {
+          kind: 'FieldDefinition',
+          name: {
+            kind: 'Name',
+            value: 'result',
+            loc: { start: 1430, end: 1436 },
+          },
+          arguments: [],
+          type: {
+            kind: 'NonNullType',
+            type: {
+              kind: 'NamedType',
+              name: {
+                kind: 'Name',
+                value: 'Topic',
+                loc: { start: 1438, end: 1443 },
+              },
+              loc: { start: 1438, end: 1443 },
+            },
+            loc: { start: 1438, end: 1444 },
+          },
+          directives: [],
+          loc: { start: 1430, end: 1444 },
+        },
+      ],
+      loc: { start: 1405, end: 1446 },
+    },
+    {
+      kind: 'UnionTypeDefinition',
+      name: {
+        kind: 'Name',
+        value: 'TopicEditPayload',
+        loc: { start: 1454, end: 1470 },
+      },
+      directives: [],
+      types: [
+        {
+          kind: 'NamedType',
+          name: {
+            kind: 'Name',
+            value: 'TopicEditResult',
+            loc: { start: 1473, end: 1488 },
+          },
+          loc: { start: 1473, end: 1488 },
+        },
+        {
+          kind: 'NamedType',
+          name: {
+            kind: 'Name',
+            value: 'PayloadError',
+            loc: { start: 1491, end: 1503 },
+          },
+          loc: { start: 1491, end: 1503 },
+        },
+      ],
+      loc: { start: 1448, end: 1503 },
+    },
+    {
+      kind: 'ObjectTypeExtension',
+      name: {
+        kind: 'Name',
+        value: 'Subscription',
+        loc: { start: 1516, end: 1528 },
+      },
+      interfaces: [],
+      directives: [],
+      fields: [
+        {
+          kind: 'FieldDefinition',
+          name: {
+            kind: 'Name',
+            value: 'profileChanges',
+            loc: { start: 1533, end: 1547 },
+          },
+          arguments: [],
+          type: {
+            kind: 'NonNullType',
+            type: {
+              kind: 'NamedType',
+              name: {
+                kind: 'Name',
+                value: 'Profile',
+                loc: { start: 1549, end: 1556 },
+              },
+              loc: { start: 1549, end: 1556 },
+            },
+            loc: { start: 1549, end: 1557 },
+          },
+          directives: [],
+          loc: { start: 1533, end: 1557 },
+        },
+      ],
+      loc: { start: 1504, end: 1559 },
+    },
+    {
+      kind: 'ObjectTypeDefinition',
+      name: { kind: 'Name', value: 'Profile', loc: { start: 1566, end: 1573 } },
+      interfaces: [],
+      directives: [],
+      fields: [
+        {
+          kind: 'FieldDefinition',
+          name: { kind: 'Name', value: 'id', loc: { start: 1578, end: 1580 } },
+          arguments: [],
+          type: {
+            kind: 'NonNullType',
+            type: {
+              kind: 'NamedType',
+              name: {
+                kind: 'Name',
+                value: 'ID',
+                loc: { start: 1582, end: 1584 },
+              },
+              loc: { start: 1582, end: 1584 },
+            },
+            loc: { start: 1582, end: 1585 },
+          },
+          directives: [],
+          loc: { start: 1578, end: 1585 },
+        },
+        {
+          kind: 'FieldDefinition',
+          name: {
+            kind: 'Name',
+            value: 'user',
+            loc: { start: 1588, end: 1592 },
+          },
+          arguments: [],
+          type: {
+            kind: 'NonNullType',
+            type: {
+              kind: 'NamedType',
+              name: {
+                kind: 'Name',
+                value: 'User',
+                loc: { start: 1594, end: 1598 },
+              },
+              loc: { start: 1594, end: 1598 },
+            },
+            loc: { start: 1594, end: 1599 },
+          },
+          directives: [],
+          loc: { start: 1588, end: 1599 },
+        },
+      ],
+      loc: { start: 1561, end: 1601 },
+    },
+    {
+      kind: 'ObjectTypeExtension',
+      name: { kind: 'Name', value: 'Query', loc: { start: 1614, end: 1619 } },
+      interfaces: [],
+      directives: [],
+      fields: [
+        {
+          kind: 'FieldDefinition',
+          name: { kind: 'Name', value: 'me', loc: { start: 1624, end: 1626 } },
+          arguments: [],
+          type: {
+            kind: 'NonNullType',
+            type: {
+              kind: 'NamedType',
+              name: {
+                kind: 'Name',
+                value: 'UserPayload',
+                loc: { start: 1628, end: 1639 },
+              },
+              loc: { start: 1628, end: 1639 },
+            },
+            loc: { start: 1628, end: 1640 },
+          },
+          directives: [],
+          loc: { start: 1624, end: 1640 },
+        },
+        {
+          kind: 'FieldDefinition',
+          name: {
+            kind: 'Name',
+            value: 'userByAccountName',
+            loc: { start: 1643, end: 1660 },
+          },
+          arguments: [
+            {
+              kind: 'InputValueDefinition',
+              name: {
+                kind: 'Name',
+                value: 'accountName',
+                loc: { start: 1661, end: 1672 },
+              },
+              type: {
+                kind: 'NonNullType',
+                type: {
+                  kind: 'NamedType',
+                  name: {
+                    kind: 'Name',
+                    value: 'String',
+                    loc: { start: 1674, end: 1680 },
+                  },
+                  loc: { start: 1674, end: 1680 },
+                },
+                loc: { start: 1674, end: 1681 },
+              },
+              directives: [],
+              loc: { start: 1661, end: 1681 },
+            },
+          ],
+          type: {
+            kind: 'NonNullType',
+            type: {
+              kind: 'NamedType',
+              name: {
+                kind: 'Name',
+                value: 'UserPayload',
+                loc: { start: 1684, end: 1695 },
+              },
+              loc: { start: 1684, end: 1695 },
+            },
+            loc: { start: 1684, end: 1696 },
+          },
+          directives: [],
+          loc: { start: 1643, end: 1696 },
+        },
+      ],
+      loc: { start: 1602, end: 1698 },
+    },
+    {
+      kind: 'ObjectTypeDefinition',
+      name: { kind: 'Name', value: 'User', loc: { start: 1705, end: 1709 } },
+      interfaces: [],
+      directives: [],
+      fields: [
+        {
+          kind: 'FieldDefinition',
+          name: { kind: 'Name', value: 'id', loc: { start: 1714, end: 1716 } },
+          arguments: [],
+          type: {
+            kind: 'NonNullType',
+            type: {
+              kind: 'NamedType',
+              name: {
+                kind: 'Name',
+                value: 'ID',
+                loc: { start: 1718, end: 1720 },
+              },
+              loc: { start: 1718, end: 1720 },
+            },
+            loc: { start: 1718, end: 1721 },
+          },
+          directives: [],
+          loc: { start: 1714, end: 1721 },
+        },
+        {
+          kind: 'FieldDefinition',
+          name: {
+            kind: 'Name',
+            value: 'name',
+            loc: { start: 1724, end: 1728 },
+          },
+          arguments: [],
+          type: {
+            kind: 'NamedType',
+            name: {
+              kind: 'Name',
+              value: 'String',
+              loc: { start: 1730, end: 1736 },
+            },
+            loc: { start: 1730, end: 1736 },
+          },
+          directives: [],
+          loc: { start: 1724, end: 1736 },
+        },
+        {
+          kind: 'FieldDefinition',
+          name: {
+            kind: 'Name',
+            value: 'accountName',
+            loc: { start: 1739, end: 1750 },
+          },
+          arguments: [],
+          type: {
+            kind: 'NonNullType',
+            type: {
+              kind: 'NamedType',
+              name: {
+                kind: 'Name',
+                value: 'String',
+                loc: { start: 1752, end: 1758 },
+              },
+              loc: { start: 1752, end: 1758 },
+            },
+            loc: { start: 1752, end: 1759 },
+          },
+          directives: [],
+          loc: { start: 1739, end: 1759 },
+        },
+        {
+          kind: 'FieldDefinition',
+          name: {
+            kind: 'Name',
+            value: 'accountWebsite',
+            loc: { start: 1762, end: 1776 },
+          },
+          arguments: [],
+          type: {
+            kind: 'NamedType',
+            name: {
+              kind: 'Name',
+              value: 'String',
+              loc: { start: 1778, end: 1784 },
+            },
+            loc: { start: 1778, end: 1784 },
+          },
+          directives: [],
+          loc: { start: 1762, end: 1784 },
+        },
+        {
+          kind: 'FieldDefinition',
+          name: {
+            kind: 'Name',
+            value: 'accountTwitter',
+            loc: { start: 1787, end: 1801 },
+          },
+          arguments: [],
+          type: {
+            kind: 'NamedType',
+            name: {
+              kind: 'Name',
+              value: 'String',
+              loc: { start: 1803, end: 1809 },
+            },
+            loc: { start: 1803, end: 1809 },
+          },
+          directives: [],
+          loc: { start: 1787, end: 1809 },
+        },
+        {
+          kind: 'FieldDefinition',
+          name: {
+            kind: 'Name',
+            value: 'accountGitHub',
+            loc: { start: 1812, end: 1825 },
+          },
+          arguments: [],
+          type: {
+            kind: 'NamedType',
+            name: {
+              kind: 'Name',
+              value: 'String',
+              loc: { start: 1827, end: 1833 },
+            },
+            loc: { start: 1827, end: 1833 },
+          },
+          directives: [],
+          loc: { start: 1812, end: 1833 },
+        },
+        {
+          kind: 'FieldDefinition',
+          name: {
+            kind: 'Name',
+            value: 'accountLinkedIn',
+            loc: { start: 1836, end: 1851 },
+          },
+          arguments: [],
+          type: {
+            kind: 'NamedType',
+            name: {
+              kind: 'Name',
+              value: 'String',
+              loc: { start: 1853, end: 1859 },
+            },
+            loc: { start: 1853, end: 1859 },
+          },
+          directives: [],
+          loc: { start: 1836, end: 1859 },
+        },
+        {
+          kind: 'FieldDefinition',
+          name: {
+            kind: 'Name',
+            value: 'avatar',
+            loc: { start: 1862, end: 1868 },
+          },
+          arguments: [],
+          type: {
+            kind: 'NamedType',
+            name: {
+              kind: 'Name',
+              value: 'String',
+              loc: { start: 1870, end: 1876 },
+            },
+            loc: { start: 1870, end: 1876 },
+          },
+          directives: [],
+          loc: { start: 1862, end: 1876 },
+        },
+      ],
+      loc: { start: 1700, end: 1878 },
+    },
+    {
+      kind: 'ObjectTypeExtension',
+      name: {
+        kind: 'Name',
+        value: 'ForeignType',
+        loc: { start: 1892, end: 1903 },
+      },
+      interfaces: [],
+      directives: [],
+      fields: [
+        {
+          kind: 'FieldDefinition',
+          name: {
+            kind: 'Name',
+            value: 'users',
+            loc: { start: 1908, end: 1913 },
+          },
+          arguments: [],
+          type: {
+            kind: 'NonNullType',
+            type: {
+              kind: 'ListType',
+              type: {
+                kind: 'NonNullType',
+                type: {
+                  kind: 'NamedType',
+                  name: {
+                    kind: 'Name',
+                    value: 'User',
+                    loc: { start: 1916, end: 1920 },
+                  },
+                  loc: { start: 1916, end: 1920 },
+                },
+                loc: { start: 1916, end: 1921 },
+              },
+              loc: { start: 1915, end: 1922 },
+            },
+            loc: { start: 1915, end: 1923 },
+          },
+          directives: [],
+          loc: { start: 1908, end: 1923 },
+        },
+      ],
+      loc: { start: 1880, end: 1925 },
+    },
+    {
+      kind: 'ObjectTypeDefinition',
+      name: {
+        kind: 'Name',
+        value: 'UserResult',
+        loc: { start: 1932, end: 1942 },
+      },
+      interfaces: [],
+      directives: [],
+      fields: [
+        {
+          kind: 'FieldDefinition',
+          name: {
+            kind: 'Name',
+            value: 'result',
+            loc: { start: 1947, end: 1953 },
+          },
+          arguments: [],
+          type: {
+            kind: 'NamedType',
+            name: {
+              kind: 'Name',
+              value: 'User',
+              loc: { start: 1955, end: 1959 },
+            },
+            loc: { start: 1955, end: 1959 },
+          },
+          directives: [],
+          loc: { start: 1947, end: 1959 },
+        },
+      ],
+      loc: { start: 1927, end: 1961 },
+    },
+    {
+      kind: 'UnionTypeDefinition',
+      name: {
+        kind: 'Name',
+        value: 'UserPayload',
+        loc: { start: 1969, end: 1980 },
+      },
+      directives: [],
+      types: [
+        {
+          kind: 'NamedType',
+          name: {
+            kind: 'Name',
+            value: 'UserResult',
+            loc: { start: 1983, end: 1993 },
+          },
+          loc: { start: 1983, end: 1993 },
+        },
+        {
+          kind: 'NamedType',
+          name: {
+            kind: 'Name',
+            value: 'PayloadError',
+            loc: { start: 1996, end: 2008 },
+          },
+          loc: { start: 1996, end: 2008 },
+        },
+      ],
+      loc: { start: 1963, end: 2008 },
+    },
+  ],
+  loc: { start: 0, end: 2009 },
+} as unknown as DocumentNode;

--- a/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type/types.generated.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type/types.generated.ts
@@ -1,0 +1,731 @@
+import {
+  GraphQLResolveInfo,
+  GraphQLScalarType,
+  GraphQLScalarTypeConfig,
+} from 'graphql';
+import { TopicMapper } from './schema/topic/topic.mappers';
+export type Maybe<T> = T | null | undefined;
+export type InputMaybe<T> = T | null | undefined;
+export type Exact<T extends { [key: string]: unknown }> = {
+  [K in keyof T]: T[K];
+};
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
+  [SubKey in K]?: Maybe<T[SubKey]>;
+};
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
+  [SubKey in K]: Maybe<T[SubKey]>;
+};
+export type MakeEmpty<
+  T extends { [key: string]: unknown },
+  K extends keyof T
+> = { [_ in K]?: never };
+export type Incremental<T> =
+  | T
+  | {
+      [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never;
+    };
+export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+export type RequireFields<T, K extends keyof T> = Omit<T, K> & {
+  [P in K]-?: NonNullable<T[P]>;
+};
+/** All built-in and custom scalars, mapped to their actual values */
+export type Scalars = {
+  ID: { input: string; output: string | number };
+  String: { input: string; output: string };
+  Boolean: { input: boolean; output: boolean };
+  Int: { input: number; output: number };
+  Float: { input: number; output: number };
+  DateTime: { input: Date | string; output: Date | string };
+  SomeRandomScalar: { input: any; output: any };
+  _FieldSet: { input: any; output: any };
+};
+
+export type Error = {
+  error: ErrorType;
+};
+
+export type ErrorType =
+  | 'FORBIDDEN_ERROR'
+  | 'INPUT_VALIDATION_ERROR'
+  | 'NOT_FOUND'
+  | 'UNEXPECTED_ERROR';
+
+export type ForeignType = {
+  __typename?: 'ForeignType';
+  id: Scalars['ID']['output'];
+  topics: Array<Topic>;
+  users: Array<User>;
+};
+
+export type Mutation = {
+  __typename?: 'Mutation';
+  topicCreate: TopicCreatePayload;
+  topicEdit: TopicEditPayload;
+};
+
+export type MutationtopicCreateArgs = {
+  input: TopicCreateInput;
+};
+
+export type MutationtopicEditArgs = {
+  input: TopicEditInput;
+};
+
+export type PaginationInput = {
+  page?: InputMaybe<Scalars['Int']['input']>;
+  recordsPerPage?: InputMaybe<Scalars['Int']['input']>;
+};
+
+export type PaginationResult = {
+  __typename?: 'PaginationResult';
+  currentPage: Scalars['Int']['output'];
+  recordsPerPage: Scalars['Int']['output'];
+  totalPageCount: Scalars['Int']['output'];
+};
+
+export type PayloadError = Error & {
+  __typename?: 'PayloadError';
+  error: ErrorType;
+};
+
+export type Profile = {
+  __typename?: 'Profile';
+  id: Scalars['ID']['output'];
+  user: User;
+};
+
+export type Query = {
+  __typename?: 'Query';
+  me: UserPayload;
+  topicById: TopicByIdPayload;
+  topicsCreatedByUser: TopicsCreatedByUserPayload;
+  userByAccountName: UserPayload;
+};
+
+export type QuerytopicByIdArgs = {
+  id: Scalars['ID']['input'];
+};
+
+export type QuerytopicsCreatedByUserArgs = {
+  input: TopicsCreatedByUserInput;
+};
+
+export type QueryuserByAccountNameArgs = {
+  accountName: Scalars['String']['input'];
+};
+
+export type Subscription = {
+  __typename?: 'Subscription';
+  profileChanges: Profile;
+};
+
+export type Topic = {
+  __typename?: 'Topic';
+  createdAt: Scalars['DateTime']['output'];
+  creator: User;
+  id: Scalars['ID']['output'];
+  name: Scalars['String']['output'];
+  url?: Maybe<Scalars['String']['output']>;
+};
+
+export type TopicByIdPayload = PayloadError | TopicByIdResult;
+
+export type TopicByIdResult = {
+  __typename?: 'TopicByIdResult';
+  result?: Maybe<Topic>;
+};
+
+export type TopicCreateInput = {
+  name: Scalars['String']['input'];
+  url?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type TopicCreatePayload = PayloadError | TopicCreateResult;
+
+export type TopicCreateResult = {
+  __typename?: 'TopicCreateResult';
+  result: Topic;
+};
+
+export type TopicEditInput = {
+  id: Scalars['ID']['input'];
+  name: Scalars['String']['input'];
+  url?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type TopicEditPayload = PayloadError | TopicEditResult;
+
+export type TopicEditResult = {
+  __typename?: 'TopicEditResult';
+  result: Topic;
+};
+
+export type TopicsCreatedByUserInput = {
+  userId: Scalars['ID']['input'];
+};
+
+export type TopicsCreatedByUserPayload =
+  | PayloadError
+  | TopicsCreatedByUserResult;
+
+export type TopicsCreatedByUserResult = {
+  __typename?: 'TopicsCreatedByUserResult';
+  result: Array<Topic>;
+};
+
+export type User = {
+  __typename?: 'User';
+  accountGitHub?: Maybe<Scalars['String']['output']>;
+  accountLinkedIn?: Maybe<Scalars['String']['output']>;
+  accountName: Scalars['String']['output'];
+  accountTwitter?: Maybe<Scalars['String']['output']>;
+  accountWebsite?: Maybe<Scalars['String']['output']>;
+  avatar?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  name?: Maybe<Scalars['String']['output']>;
+};
+
+export type UserPayload = PayloadError | UserResult;
+
+export type UserResult = {
+  __typename?: 'UserResult';
+  result?: Maybe<User>;
+};
+
+export type ResolverTypeWrapper<T> = Promise<T> | T;
+
+export type ReferenceResolver<TResult, TReference, TContext> = (
+  reference: TReference,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => Promise<TResult> | TResult;
+
+type ScalarCheck<T, S> = S extends true ? T : NullableCheck<T, S>;
+type NullableCheck<T, S> = Maybe<T> extends T
+  ? Maybe<ListCheck<NonNullable<T>, S>>
+  : ListCheck<T, S>;
+type ListCheck<T, S> = T extends (infer U)[]
+  ? NullableCheck<U, S>[]
+  : GraphQLRecursivePick<T, S>;
+export type GraphQLRecursivePick<T, S> = {
+  [K in keyof T & keyof S]: ScalarCheck<T[K], S[K]>;
+};
+
+export type ResolverWithResolve<TResult, TParent, TContext, TArgs> = {
+  resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
+};
+export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> =
+  | ResolverFn<TResult, TParent, TContext, TArgs>
+  | ResolverWithResolve<TResult, TParent, TContext, TArgs>;
+
+export type ResolverFn<TResult, TParent, TContext, TArgs> = (
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => Promise<TResult> | TResult;
+
+export type SubscriptionSubscribeFn<TResult, TParent, TContext, TArgs> = (
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => AsyncIterable<TResult> | Promise<AsyncIterable<TResult>>;
+
+export type SubscriptionResolveFn<TResult, TParent, TContext, TArgs> = (
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => TResult | Promise<TResult>;
+
+export interface SubscriptionSubscriberObject<
+  TResult,
+  TKey extends string,
+  TParent,
+  TContext,
+  TArgs
+> {
+  subscribe: SubscriptionSubscribeFn<
+    { [key in TKey]: TResult },
+    TParent,
+    TContext,
+    TArgs
+  >;
+  resolve?: SubscriptionResolveFn<
+    TResult,
+    { [key in TKey]: TResult },
+    TContext,
+    TArgs
+  >;
+}
+
+export interface SubscriptionResolverObject<TResult, TParent, TContext, TArgs> {
+  subscribe: SubscriptionSubscribeFn<any, TParent, TContext, TArgs>;
+  resolve: SubscriptionResolveFn<TResult, any, TContext, TArgs>;
+}
+
+export type SubscriptionObject<
+  TResult,
+  TKey extends string,
+  TParent,
+  TContext,
+  TArgs
+> =
+  | SubscriptionSubscriberObject<TResult, TKey, TParent, TContext, TArgs>
+  | SubscriptionResolverObject<TResult, TParent, TContext, TArgs>;
+
+export type SubscriptionResolver<
+  TResult,
+  TKey extends string,
+  TParent = {},
+  TContext = {},
+  TArgs = {}
+> =
+  | ((
+      ...args: any[]
+    ) => SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>)
+  | SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>;
+
+export type TypeResolveFn<TTypes, TParent = {}, TContext = {}> = (
+  parent: TParent,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => Maybe<TTypes> | Promise<Maybe<TTypes>>;
+
+export type IsTypeOfResolverFn<T = {}, TContext = {}> = (
+  obj: T,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => boolean | Promise<boolean>;
+
+export type NextResolverFn<T> = () => Promise<T>;
+
+export type DirectiveResolverFn<
+  TResult = {},
+  TParent = {},
+  TContext = {},
+  TArgs = {}
+> = (
+  next: NextResolverFn<TResult>,
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => TResult | Promise<TResult>;
+
+/** Mapping of union types */
+export type ResolversUnionTypes<RefType extends Record<string, unknown>> = {
+  TopicByIdPayload:
+    | (PayloadError & { __typename: 'PayloadError' })
+    | (Omit<TopicByIdResult, 'result'> & {
+        result?: Maybe<RefType['Topic']>;
+      } & { __typename: 'TopicByIdResult' });
+  TopicCreatePayload:
+    | (PayloadError & { __typename: 'PayloadError' })
+    | (Omit<TopicCreateResult, 'result'> & { result: RefType['Topic'] } & {
+        __typename: 'TopicCreateResult';
+      });
+  TopicEditPayload:
+    | (PayloadError & { __typename: 'PayloadError' })
+    | (Omit<TopicEditResult, 'result'> & { result: RefType['Topic'] } & {
+        __typename: 'TopicEditResult';
+      });
+  TopicsCreatedByUserPayload:
+    | (PayloadError & { __typename: 'PayloadError' })
+    | (Omit<TopicsCreatedByUserResult, 'result'> & {
+        result: Array<RefType['Topic']>;
+      } & { __typename: 'TopicsCreatedByUserResult' });
+  UserPayload:
+    | (PayloadError & { __typename: 'PayloadError' })
+    | (UserResult & { __typename: 'UserResult' });
+};
+
+/** Mapping of interface types */
+export type ResolversInterfaceTypes<RefType extends Record<string, unknown>> = {
+  Error: PayloadError & { __typename: 'PayloadError' };
+};
+
+/** Mapping between all available schema types and the resolvers types */
+export type ResolversTypes = {
+  DateTime: ResolverTypeWrapper<Scalars['DateTime']['output']>;
+  Error: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['Error']>;
+  ErrorType: ErrorType;
+  ForeignType: ResolverTypeWrapper<
+    Omit<ForeignType, 'topics'> & { topics: Array<ResolversTypes['Topic']> }
+  >;
+  ID: ResolverTypeWrapper<Scalars['ID']['output']>;
+  Mutation: ResolverTypeWrapper<{}>;
+  PaginationInput: PaginationInput;
+  Int: ResolverTypeWrapper<Scalars['Int']['output']>;
+  PaginationResult: ResolverTypeWrapper<PaginationResult>;
+  PayloadError: ResolverTypeWrapper<PayloadError>;
+  Profile: ResolverTypeWrapper<Profile>;
+  Query: ResolverTypeWrapper<{}>;
+  String: ResolverTypeWrapper<Scalars['String']['output']>;
+  SomeRandomScalar: ResolverTypeWrapper<Scalars['SomeRandomScalar']['output']>;
+  Subscription: ResolverTypeWrapper<{}>;
+  Topic: ResolverTypeWrapper<TopicMapper>;
+  TopicByIdPayload: ResolverTypeWrapper<
+    ResolversUnionTypes<ResolversTypes>['TopicByIdPayload']
+  >;
+  TopicByIdResult: ResolverTypeWrapper<
+    Omit<TopicByIdResult, 'result'> & {
+      result?: Maybe<ResolversTypes['Topic']>;
+    }
+  >;
+  TopicCreateInput: TopicCreateInput;
+  TopicCreatePayload: ResolverTypeWrapper<
+    ResolversUnionTypes<ResolversTypes>['TopicCreatePayload']
+  >;
+  TopicCreateResult: ResolverTypeWrapper<
+    Omit<TopicCreateResult, 'result'> & { result: ResolversTypes['Topic'] }
+  >;
+  TopicEditInput: TopicEditInput;
+  TopicEditPayload: ResolverTypeWrapper<
+    ResolversUnionTypes<ResolversTypes>['TopicEditPayload']
+  >;
+  TopicEditResult: ResolverTypeWrapper<
+    Omit<TopicEditResult, 'result'> & { result: ResolversTypes['Topic'] }
+  >;
+  TopicsCreatedByUserInput: TopicsCreatedByUserInput;
+  TopicsCreatedByUserPayload: ResolverTypeWrapper<
+    ResolversUnionTypes<ResolversTypes>['TopicsCreatedByUserPayload']
+  >;
+  TopicsCreatedByUserResult: ResolverTypeWrapper<
+    Omit<TopicsCreatedByUserResult, 'result'> & {
+      result: Array<ResolversTypes['Topic']>;
+    }
+  >;
+  User: ResolverTypeWrapper<User>;
+  UserPayload: ResolverTypeWrapper<
+    ResolversUnionTypes<ResolversTypes>['UserPayload']
+  >;
+  UserResult: ResolverTypeWrapper<UserResult>;
+  Boolean: ResolverTypeWrapper<Scalars['Boolean']['output']>;
+};
+
+/** Mapping between all available schema types and the resolvers parents */
+export type ResolversParentTypes = {
+  DateTime: Scalars['DateTime']['output'];
+  Error: ResolversInterfaceTypes<ResolversParentTypes>['Error'];
+  ForeignType: Omit<ForeignType, 'topics'> & {
+    topics: Array<ResolversParentTypes['Topic']>;
+  };
+  ID: Scalars['ID']['output'];
+  Mutation: {};
+  PaginationInput: PaginationInput;
+  Int: Scalars['Int']['output'];
+  PaginationResult: PaginationResult;
+  PayloadError: PayloadError;
+  Profile: Profile;
+  Query: {};
+  String: Scalars['String']['output'];
+  SomeRandomScalar: Scalars['SomeRandomScalar']['output'];
+  Subscription: {};
+  Topic: TopicMapper;
+  TopicByIdPayload: ResolversUnionTypes<ResolversParentTypes>['TopicByIdPayload'];
+  TopicByIdResult: Omit<TopicByIdResult, 'result'> & {
+    result?: Maybe<ResolversParentTypes['Topic']>;
+  };
+  TopicCreateInput: TopicCreateInput;
+  TopicCreatePayload: ResolversUnionTypes<ResolversParentTypes>['TopicCreatePayload'];
+  TopicCreateResult: Omit<TopicCreateResult, 'result'> & {
+    result: ResolversParentTypes['Topic'];
+  };
+  TopicEditInput: TopicEditInput;
+  TopicEditPayload: ResolversUnionTypes<ResolversParentTypes>['TopicEditPayload'];
+  TopicEditResult: Omit<TopicEditResult, 'result'> & {
+    result: ResolversParentTypes['Topic'];
+  };
+  TopicsCreatedByUserInput: TopicsCreatedByUserInput;
+  TopicsCreatedByUserPayload: ResolversUnionTypes<ResolversParentTypes>['TopicsCreatedByUserPayload'];
+  TopicsCreatedByUserResult: Omit<TopicsCreatedByUserResult, 'result'> & {
+    result: Array<ResolversParentTypes['Topic']>;
+  };
+  User: User;
+  UserPayload: ResolversUnionTypes<ResolversParentTypes>['UserPayload'];
+  UserResult: UserResult;
+  Boolean: Scalars['Boolean']['output'];
+};
+
+export interface DateTimeScalarConfig
+  extends GraphQLScalarTypeConfig<ResolversTypes['DateTime'], any> {
+  name: 'DateTime';
+}
+
+export type ErrorResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['Error'] = ResolversParentTypes['Error']
+> = {
+  __resolveType?: TypeResolveFn<'PayloadError', ParentType, ContextType>;
+  error?: Resolver<ResolversTypes['ErrorType'], ParentType, ContextType>;
+};
+
+export type ForeignTypeResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['ForeignType'] = ResolversParentTypes['ForeignType']
+> = {
+  __resolveReference?: ReferenceResolver<
+    Maybe<ResolversTypes['ForeignType']>,
+    { __typename: 'ForeignType' } & GraphQLRecursivePick<
+      ParentType,
+      { id: true }
+    >,
+    ContextType
+  >;
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  topics?: Resolver<Array<ResolversTypes['Topic']>, ParentType, ContextType>;
+  users?: Resolver<Array<ResolversTypes['User']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type MutationResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']
+> = {
+  topicCreate?: Resolver<
+    ResolversTypes['TopicCreatePayload'],
+    ParentType,
+    ContextType,
+    RequireFields<MutationtopicCreateArgs, 'input'>
+  >;
+  topicEdit?: Resolver<
+    ResolversTypes['TopicEditPayload'],
+    ParentType,
+    ContextType,
+    RequireFields<MutationtopicEditArgs, 'input'>
+  >;
+};
+
+export type PaginationResultResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['PaginationResult'] = ResolversParentTypes['PaginationResult']
+> = {
+  currentPage?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  recordsPerPage?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  totalPageCount?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type PayloadErrorResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['PayloadError'] = ResolversParentTypes['PayloadError']
+> = {
+  error?: Resolver<ResolversTypes['ErrorType'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type ProfileResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['Profile'] = ResolversParentTypes['Profile']
+> = {
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  user?: Resolver<ResolversTypes['User'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type QueryResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']
+> = {
+  me?: Resolver<ResolversTypes['UserPayload'], ParentType, ContextType>;
+  topicById?: Resolver<
+    ResolversTypes['TopicByIdPayload'],
+    ParentType,
+    ContextType,
+    RequireFields<QuerytopicByIdArgs, 'id'>
+  >;
+  topicsCreatedByUser?: Resolver<
+    ResolversTypes['TopicsCreatedByUserPayload'],
+    ParentType,
+    ContextType,
+    RequireFields<QuerytopicsCreatedByUserArgs, 'input'>
+  >;
+  userByAccountName?: Resolver<
+    ResolversTypes['UserPayload'],
+    ParentType,
+    ContextType,
+    RequireFields<QueryuserByAccountNameArgs, 'accountName'>
+  >;
+};
+
+export interface SomeRandomScalarScalarConfig
+  extends GraphQLScalarTypeConfig<ResolversTypes['SomeRandomScalar'], any> {
+  name: 'SomeRandomScalar';
+}
+
+export type SubscriptionResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['Subscription'] = ResolversParentTypes['Subscription']
+> = {
+  profileChanges?: SubscriptionResolver<
+    ResolversTypes['Profile'],
+    'profileChanges',
+    ParentType,
+    ContextType
+  >;
+};
+
+export type TopicResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['Topic'] = ResolversParentTypes['Topic']
+> = {
+  createdAt?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
+  creator?: Resolver<ResolversTypes['User'], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  url?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type TopicByIdPayloadResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['TopicByIdPayload'] = ResolversParentTypes['TopicByIdPayload']
+> = {
+  __resolveType?: TypeResolveFn<
+    'PayloadError' | 'TopicByIdResult',
+    ParentType,
+    ContextType
+  >;
+};
+
+export type TopicByIdResultResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['TopicByIdResult'] = ResolversParentTypes['TopicByIdResult']
+> = {
+  result?: Resolver<Maybe<ResolversTypes['Topic']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type TopicCreatePayloadResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['TopicCreatePayload'] = ResolversParentTypes['TopicCreatePayload']
+> = {
+  __resolveType?: TypeResolveFn<
+    'PayloadError' | 'TopicCreateResult',
+    ParentType,
+    ContextType
+  >;
+};
+
+export type TopicCreateResultResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['TopicCreateResult'] = ResolversParentTypes['TopicCreateResult']
+> = {
+  result?: Resolver<ResolversTypes['Topic'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type TopicEditPayloadResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['TopicEditPayload'] = ResolversParentTypes['TopicEditPayload']
+> = {
+  __resolveType?: TypeResolveFn<
+    'PayloadError' | 'TopicEditResult',
+    ParentType,
+    ContextType
+  >;
+};
+
+export type TopicEditResultResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['TopicEditResult'] = ResolversParentTypes['TopicEditResult']
+> = {
+  result?: Resolver<ResolversTypes['Topic'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type TopicsCreatedByUserPayloadResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['TopicsCreatedByUserPayload'] = ResolversParentTypes['TopicsCreatedByUserPayload']
+> = {
+  __resolveType?: TypeResolveFn<
+    'PayloadError' | 'TopicsCreatedByUserResult',
+    ParentType,
+    ContextType
+  >;
+};
+
+export type TopicsCreatedByUserResultResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['TopicsCreatedByUserResult'] = ResolversParentTypes['TopicsCreatedByUserResult']
+> = {
+  result?: Resolver<Array<ResolversTypes['Topic']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type UserResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User']
+> = {
+  accountGitHub?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  accountLinkedIn?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  accountName?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  accountTwitter?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  accountWebsite?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  avatar?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type UserPayloadResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['UserPayload'] = ResolversParentTypes['UserPayload']
+> = {
+  __resolveType?: TypeResolveFn<
+    'PayloadError' | 'UserResult',
+    ParentType,
+    ContextType
+  >;
+};
+
+export type UserResultResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['UserResult'] = ResolversParentTypes['UserResult']
+> = {
+  result?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type Resolvers<ContextType = any> = {
+  DateTime?: GraphQLScalarType;
+  Error?: ErrorResolvers<ContextType>;
+  ForeignType?: ForeignTypeResolvers<ContextType>;
+  Mutation?: MutationResolvers<ContextType>;
+  PaginationResult?: PaginationResultResolvers<ContextType>;
+  PayloadError?: PayloadErrorResolvers<ContextType>;
+  Profile?: ProfileResolvers<ContextType>;
+  Query?: QueryResolvers<ContextType>;
+  SomeRandomScalar?: GraphQLScalarType;
+  Subscription?: SubscriptionResolvers<ContextType>;
+  Topic?: TopicResolvers<ContextType>;
+  TopicByIdPayload?: TopicByIdPayloadResolvers<ContextType>;
+  TopicByIdResult?: TopicByIdResultResolvers<ContextType>;
+  TopicCreatePayload?: TopicCreatePayloadResolvers<ContextType>;
+  TopicCreateResult?: TopicCreateResultResolvers<ContextType>;
+  TopicEditPayload?: TopicEditPayloadResolvers<ContextType>;
+  TopicEditResult?: TopicEditResultResolvers<ContextType>;
+  TopicsCreatedByUserPayload?: TopicsCreatedByUserPayloadResolvers<ContextType>;
+  TopicsCreatedByUserResult?: TopicsCreatedByUserResultResolvers<ContextType>;
+  User?: UserResolvers<ContextType>;
+  UserPayload?: UserPayloadResolvers<ContextType>;
+  UserResult?: UserResultResolvers<ContextType>;
+};

--- a/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type/user/resolvers/ForeignType.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type/user/resolvers/ForeignType.ts
@@ -1,0 +1,7 @@
+import type { ForeignTypeResolvers } from './../../types.generated';
+export const ForeignType: Pick<
+  ForeignTypeResolvers,
+  'users' | '__resolveReference'
+> = {
+  /* Implement ForeignType resolver logic here */
+};

--- a/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type/user/resolvers/Profile.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type/user/resolvers/Profile.ts
@@ -1,0 +1,4 @@
+import type { ProfileResolvers } from './../../types.generated';
+export const Profile: ProfileResolvers = {
+  /* Implement Profile resolver logic here */
+};

--- a/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type/user/resolvers/Query/me.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type/user/resolvers/Query/me.ts
@@ -1,0 +1,8 @@
+import type { QueryResolvers } from './../../../types.generated';
+export const me: NonNullable<QueryResolvers['me']> = async (
+  _parent,
+  _arg,
+  _ctx
+) => {
+  /* Implement Query.me resolver logic here */
+};

--- a/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type/user/resolvers/Query/userByAccountName.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type/user/resolvers/Query/userByAccountName.ts
@@ -1,0 +1,6 @@
+import type { QueryResolvers } from './../../../types.generated';
+export const userByAccountName: NonNullable<
+  QueryResolvers['userByAccountName']
+> = async (_parent, _arg, _ctx) => {
+  /* Implement Query.userByAccountName resolver logic here */
+};

--- a/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type/user/resolvers/Subscription/profileChanges.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type/user/resolvers/Subscription/profileChanges.ts
@@ -1,0 +1,8 @@
+import type { SubscriptionResolvers } from './../../../types.generated';
+export const profileChanges: NonNullable<
+  SubscriptionResolvers['profileChanges']
+> = {
+  subscribe: async (_parent, _arg, _ctx) => {
+    /* Implement Subscription.profileChanges resolver logic here */
+  },
+};

--- a/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type/user/resolvers/User.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type/user/resolvers/User.ts
@@ -1,0 +1,4 @@
+import type { UserResolvers } from './../../types.generated';
+export const User: UserResolvers = {
+  /* Implement User resolver logic here */
+};

--- a/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type/user/resolvers/UserResult.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type/user/resolvers/UserResult.ts
@@ -1,0 +1,4 @@
+import type { UserResultResolvers } from './../../types.generated';
+export const UserResult: UserResultResolvers = {
+  /* Implement UserResult resolver logic here */
+};

--- a/packages/typescript-resolver-files/src/generateResolverFiles/generateResolverFiles.ts
+++ b/packages/typescript-resolver-files/src/generateResolverFiles/generateResolverFiles.ts
@@ -80,6 +80,16 @@ export const generateResolverFiles = (
           return res;
         }, {});
 
+        let pickReferenceResolver = false;
+        if (ctx.config.federationEnabled) {
+          namedType.astNode?.directives?.forEach((d) => {
+            if (d.name.value === 'key') {
+              pickReferenceResolver = true;
+              return;
+            }
+          });
+        }
+
         // If there are multiple object type files to generate e.g. `extend type ObjectType` is used across multiple modules
         // Then, generate one file for each location
         const fieldsToGenerate = Object.entries(fieldsByGraphQLModule);
@@ -87,7 +97,10 @@ export const generateResolverFiles = (
           fieldsToGenerate.forEach(
             ([_, { firstFieldLocation, fieldNodes }]) => {
               const fieldsToPick = fieldNodes.map((field) => field.name);
-              visitNamedType<{ fieldsToPick: string[] }>(
+              visitNamedType<{
+                fieldsToPick: string[];
+                pickReferenceResolver: boolean;
+              }>(
                 {
                   namedType,
                   resolverName: namedType.name,
@@ -95,6 +108,7 @@ export const generateResolverFiles = (
                   location: firstFieldLocation,
                   visitor,
                   fieldsToPick,
+                  pickReferenceResolver,
                 },
                 ctx
               );

--- a/packages/typescript-resolver-files/src/generateResolverFiles/generateResolverFiles.ts
+++ b/packages/typescript-resolver-files/src/generateResolverFiles/generateResolverFiles.ts
@@ -81,13 +81,10 @@ export const generateResolverFiles = (
         }, {});
 
         let pickReferenceResolver = false;
-        if (ctx.config.federationEnabled) {
-          namedType.astNode?.directives?.forEach((d) => {
-            if (d.name.value === 'key') {
-              pickReferenceResolver = true;
-              return;
-            }
-          });
+        if (ctx.config.federationEnabled && namedType.astNode?.directives) {
+          pickReferenceResolver = namedType.astNode.directives.some(
+            (d) => d.name.value === 'key'
+          );
         }
 
         // If there are multiple object type files to generate e.g. `extend type ObjectType` is used across multiple modules

--- a/packages/typescript-resolver-files/src/generateResolverFiles/handleGraphQLObjectType.ts
+++ b/packages/typescript-resolver-files/src/generateResolverFiles/handleGraphQLObjectType.ts
@@ -3,7 +3,10 @@ import { printImportLine } from '../utils';
 
 export const handleGraphQLObjectType: GraphQLTypeHandler<
   null,
-  { fieldsToPick?: string[] }
+  {
+    fieldsToPick?: string[];
+    pickReferenceResolver?: boolean;
+  }
 > = (
   {
     fieldFilePath,
@@ -12,6 +15,7 @@ export const handleGraphQLObjectType: GraphQLTypeHandler<
     resolversTypeMeta,
     moduleName,
     fieldsToPick = [], // If fieldsToPick.length === 0, it means the current object handles all resolvers
+    pickReferenceResolver,
   },
   {
     result,
@@ -24,6 +28,10 @@ export const handleGraphQLObjectType: GraphQLTypeHandler<
 ) => {
   if (!resolverGeneration.object) {
     return;
+  }
+
+  if (fieldsToPick.length > 0 && pickReferenceResolver) {
+    fieldsToPick.push('__resolveReference');
   }
 
   // `typeString` contains the resolver type

--- a/packages/typescript-resolver-files/src/generateResolverFiles/types.ts
+++ b/packages/typescript-resolver-files/src/generateResolverFiles/types.ts
@@ -74,6 +74,7 @@ export interface GenerateResolverFilesContext {
     graphQLObjectTypeResolversToGenerate: GraphQLObjectTypeResolversToGenerate;
     fixObjectTypeResolvers: ParsedPresetConfig['fixObjectTypeResolvers'];
     emitLegacyCommonJSImports: boolean;
+    federationEnabled: boolean;
   };
   result: {
     files: Record<string, StandardFile | ResolverFile>;

--- a/packages/typescript-resolver-files/src/preset.ts
+++ b/packages/typescript-resolver-files/src/preset.ts
@@ -230,6 +230,7 @@ export const preset: Types.OutputPreset<RawPresetConfig> = {
               ...mergedConfig.externalResolvers,
             },
             emitLegacyCommonJSImports,
+            federationEnabled: Boolean(typesPluginsConfig.federation),
           },
           result,
         }),


### PR DESCRIPTION
First off, thanks for making this package! It's real nice having a schema-first approach in TypeScript so very similar to `gqlgen`.

This PR attempts to address an issue where combining a federated type + locally extending that type removes `__resolveReference` from the generated type stubs.

This naively picks this field in addition to other fields being picked. I couldn't think of a great way to determine the _exact_ definition to pick, but since the field is optional I figure there's not much harm.

Please let me know if there's anything you'd like changed and I'll be happy to address. (or feel free to address yourself if so inclined)