### PR TITLE
Update args for missing mapper resolvers

### DIFF
--- a/.changeset/heavy-suits-wait.md
+++ b/.changeset/heavy-suits-wait.md
@@ -1,0 +1,5 @@
+---
+'@eddeee888/gcg-typescript-resolver-files': patch
+---
+
+Add params to generated resolvers

--- a/packages/typescript-resolver-files-e2e/src/test-esm-import/schema/topic/resolvers/Topic.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-esm-import/schema/topic/resolvers/Topic.ts
@@ -1,7 +1,7 @@
 import type { TopicResolvers } from './../../types.generated.js';
 export const Topic: TopicResolvers = {
   /* Implement Topic resolver logic here */
-  creator: () => {
+  creator: async (_parent, _arg, _ctx) => {
     /* Topic.creator resolver is required because Topic.creator exists but TopicMapper.creator does not */
   },
 };

--- a/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-base/book-store-v2_new_again-final_v3/resolvers/Topic.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-base/book-store-v2_new_again-final_v3/resolvers/Topic.ts
@@ -1,7 +1,7 @@
 import type { TopicResolvers } from './../../types.generated';
 export const Topic: Pick<TopicResolvers, 'bookStore_for_topic'> = {
   /* Implement Topic resolver logic here */
-  bookStore_for_topic: () => {
+  bookStore_for_topic: async (_parent, _arg, _ctx) => {
     /* Topic.bookStore_for_topic resolver is required because Topic.bookStore_for_topic exists but TopicMapper.bookStore_for_topic does not */
   },
 };

--- a/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-base/topic/resolvers/Topic.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-base/topic/resolvers/Topic.ts
@@ -13,22 +13,46 @@ export const Topic: Pick<
   | 'url'
 > = {
   /* Implement Topic resolver logic here */
-  extendedTopicFieldInDifferentFileAndSameModule1: () => {
+  extendedTopicFieldInDifferentFileAndSameModule1: async (
+    _parent,
+    _arg,
+    _ctx
+  ) => {
     /* Topic.extendedTopicFieldInDifferentFileAndSameModule1 resolver is required because Topic.extendedTopicFieldInDifferentFileAndSameModule1 exists but TopicMapper.extendedTopicFieldInDifferentFileAndSameModule1 does not */
   },
-  extendedTopicFieldInDifferentFileAndSameModule2: () => {
+  extendedTopicFieldInDifferentFileAndSameModule2: async (
+    _parent,
+    _arg,
+    _ctx
+  ) => {
     /* Topic.extendedTopicFieldInDifferentFileAndSameModule2 resolver is required because Topic.extendedTopicFieldInDifferentFileAndSameModule2 exists but TopicMapper.extendedTopicFieldInDifferentFileAndSameModule2 does not */
   },
-  extendedTopicFieldInDifferentFileAndSameModule3: () => {
+  extendedTopicFieldInDifferentFileAndSameModule3: async (
+    _parent,
+    _arg,
+    _ctx
+  ) => {
     /* Topic.extendedTopicFieldInDifferentFileAndSameModule3 resolver is required because Topic.extendedTopicFieldInDifferentFileAndSameModule3 exists but TopicMapper.extendedTopicFieldInDifferentFileAndSameModule3 does not */
   },
-  extendedTopicFieldInTheSameFileAndSameModule1: () => {
+  extendedTopicFieldInTheSameFileAndSameModule1: async (
+    _parent,
+    _arg,
+    _ctx
+  ) => {
     /* Topic.extendedTopicFieldInTheSameFileAndSameModule1 resolver is required because Topic.extendedTopicFieldInTheSameFileAndSameModule1 exists but TopicMapper.extendedTopicFieldInTheSameFileAndSameModule1 does not */
   },
-  extendedTopicFieldInTheSameFileAndSameModule2: () => {
+  extendedTopicFieldInTheSameFileAndSameModule2: async (
+    _parent,
+    _arg,
+    _ctx
+  ) => {
     /* Topic.extendedTopicFieldInTheSameFileAndSameModule2 resolver is required because Topic.extendedTopicFieldInTheSameFileAndSameModule2 exists but TopicMapper.extendedTopicFieldInTheSameFileAndSameModule2 does not */
   },
-  extendedTopicFieldInTheSameFileAndSameModule3: () => {
+  extendedTopicFieldInTheSameFileAndSameModule3: async (
+    _parent,
+    _arg,
+    _ctx
+  ) => {
     /* Topic.extendedTopicFieldInTheSameFileAndSameModule3 resolver is required because Topic.extendedTopicFieldInTheSameFileAndSameModule3 exists but TopicMapper.extendedTopicFieldInTheSameFileAndSameModule3 does not */
   },
 };

--- a/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-base/user/resolvers/Topic.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-base/user/resolvers/Topic.ts
@@ -7,17 +7,29 @@ export const Topic: Pick<
   | 'extendedTopicFieldInDifferentFileAndDifferentModule3'
 > = {
   /* Implement Topic resolver logic here */
-  creator: ({ creator }) => {
+  creator: ({ creator }, _arg, _ctx) => {
     /* Topic.creator resolver is required because Topic.creator and TopicMapper.creator are not compatible */
     return creator;
   },
-  extendedTopicFieldInDifferentFileAndDifferentModule1: () => {
+  extendedTopicFieldInDifferentFileAndDifferentModule1: async (
+    _parent,
+    _arg,
+    _ctx
+  ) => {
     /* Topic.extendedTopicFieldInDifferentFileAndDifferentModule1 resolver is required because Topic.extendedTopicFieldInDifferentFileAndDifferentModule1 exists but TopicMapper.extendedTopicFieldInDifferentFileAndDifferentModule1 does not */
   },
-  extendedTopicFieldInDifferentFileAndDifferentModule2: () => {
+  extendedTopicFieldInDifferentFileAndDifferentModule2: async (
+    _parent,
+    _arg,
+    _ctx
+  ) => {
     /* Topic.extendedTopicFieldInDifferentFileAndDifferentModule2 resolver is required because Topic.extendedTopicFieldInDifferentFileAndDifferentModule2 exists but TopicMapper.extendedTopicFieldInDifferentFileAndDifferentModule2 does not */
   },
-  extendedTopicFieldInDifferentFileAndDifferentModule3: () => {
+  extendedTopicFieldInDifferentFileAndDifferentModule3: async (
+    _parent,
+    _arg,
+    _ctx
+  ) => {
     /* Topic.extendedTopicFieldInDifferentFileAndDifferentModule3 resolver is required because Topic.extendedTopicFieldInDifferentFileAndDifferentModule3 exists but TopicMapper.extendedTopicFieldInDifferentFileAndDifferentModule3 does not */
   },
 };

--- a/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type/topic/resolvers/Topic.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-extended-object-types/schema-federated-extended-object-type/topic/resolvers/Topic.ts
@@ -1,7 +1,7 @@
 import type { TopicResolvers } from './../../types.generated';
 export const Topic: TopicResolvers = {
   /* Implement Topic resolver logic here */
-  creator: () => {
+  creator: async (_parent, _arg, _ctx) => {
     /* Topic.creator resolver is required because Topic.creator exists but TopicMapper.creator does not */
   },
 };

--- a/packages/typescript-resolver-files-e2e/src/test-mappers-vs-schema-types/modules/user/resolvers/Country.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-mappers-vs-schema-types/modules/user/resolvers/Country.ts
@@ -1,7 +1,7 @@
 import type { CountryResolvers } from './../../types.generated';
 export const Country: CountryResolvers = {
   /* Implement Country resolver logic here */
-  name: () => {
+  name: async (_parent, _arg, _ctx) => {
     /* Country.name resolver is required because Country.name exists but CountryMapper.name does not */
   },
 };

--- a/packages/typescript-resolver-files-e2e/src/test-mappers-vs-schema-types/modules/user/resolvers/Profile.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-mappers-vs-schema-types/modules/user/resolvers/Profile.ts
@@ -1,7 +1,7 @@
 import type { ProfileResolvers } from './../../types.generated';
 export const Profile: ProfileResolvers = {
   /* Implement Profile resolver logic here */
-  user: () => {
+  user: async (_parent, _arg, _ctx) => {
     /* Profile.user resolver is required because Profile.user exists but ProfileMapper.user does not */
   },
 };

--- a/packages/typescript-resolver-files-e2e/src/test-mappers-vs-schema-types/modules/user/resolvers/ProfileMeta.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-mappers-vs-schema-types/modules/user/resolvers/ProfileMeta.ts
@@ -1,10 +1,10 @@
 import type { ProfileMetaResolvers } from './../../types.generated';
 export const ProfileMeta: ProfileMetaResolvers = {
   /* Implement ProfileMeta resolver logic here */
-  isCompleted: () => {
+  isCompleted: async (_parent, _arg, _ctx) => {
     /* ProfileMeta.isCompleted resolver is required because ProfileMeta.isCompleted exists but ProfileMetaMapper.isCompleted does not */
   },
-  score: ({ score }) => {
+  score: ({ score }, _arg, _ctx) => {
     /* ProfileMeta.score resolver is required because ProfileMeta.score and ProfileMetaMapper.score are not compatible */
     return score;
   },

--- a/packages/typescript-resolver-files-e2e/src/test-mappers-vs-schema-types/modules/user/resolvers/User.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-mappers-vs-schema-types/modules/user/resolvers/User.ts
@@ -1,13 +1,13 @@
 import type { UserResolvers } from './../../types.generated';
 export const User: UserResolvers = {
   /* Implement User resolver logic here */
-  accountGitHub: () => {
+  accountGitHub: async (_parent, _arg, _ctx) => {
     /* User.accountGitHub resolver is required because User.accountGitHub exists but UserMapper.accountGitHub does not */
   },
-  accountGoogle: () => {
+  accountGoogle: async (_parent, _arg, _ctx) => {
     /* User.accountGoogle resolver is required because User.accountGoogle exists but UserMapper.accountGoogle does not */
   },
-  fullName: () => {
+  fullName: async (_parent, _arg, _ctx) => {
     /* User.fullName resolver is required because User.fullName exists but UserMapper.fullName does not */
   },
 };

--- a/packages/typescript-resolver-files-e2e/src/test-mappers/modules/user/resolvers/Profile.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-mappers/modules/user/resolvers/Profile.ts
@@ -1,7 +1,7 @@
 import type { ProfileResolvers } from './../../types.generated';
 export const Profile: ProfileResolvers = {
   /* Implement Profile resolver logic here */
-  user: () => {
+  user: async (_parent, _arg, _ctx) => {
     /* Profile.user resolver is required because Profile.user exists but Profile_Mapper.user does not */
   },
 };

--- a/packages/typescript-resolver-files-e2e/src/test-merged/graphql/resolvers/Topic.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-merged/graphql/resolvers/Topic.ts
@@ -1,7 +1,7 @@
 import type { TopicResolvers } from './types.generated';
 export const Topic: TopicResolvers = {
   /* Implement Topic resolver logic here */
-  creator: () => {
+  creator: async (_parent, _arg, _ctx) => {
     /* Topic.creator resolver is required because Topic.creator exists but TopicMapper.creator does not */
   },
 };

--- a/packages/typescript-resolver-files-e2e/src/test-merged/graphql/resolvers/User.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-merged/graphql/resolvers/User.ts
@@ -1,25 +1,25 @@
 import type { UserResolvers } from './types.generated';
 export const User: UserResolvers = {
   /* Implement User resolver logic here */
-  accountGitHub: () => {
+  accountGitHub: async (_parent, _arg, _ctx) => {
     /* User.accountGitHub resolver is required because User.accountGitHub exists but UserMapper.accountGitHub does not */
   },
-  accountLinkedIn: () => {
+  accountLinkedIn: async (_parent, _arg, _ctx) => {
     /* User.accountLinkedIn resolver is required because User.accountLinkedIn exists but UserMapper.accountLinkedIn does not */
   },
-  accountName: () => {
+  accountName: async (_parent, _arg, _ctx) => {
     /* User.accountName resolver is required because User.accountName exists but UserMapper.accountName does not */
   },
-  accountTwitter: () => {
+  accountTwitter: async (_parent, _arg, _ctx) => {
     /* User.accountTwitter resolver is required because User.accountTwitter exists but UserMapper.accountTwitter does not */
   },
-  accountWebsite: () => {
+  accountWebsite: async (_parent, _arg, _ctx) => {
     /* User.accountWebsite resolver is required because User.accountWebsite exists but UserMapper.accountWebsite does not */
   },
-  avatar: () => {
+  avatar: async (_parent, _arg, _ctx) => {
     /* User.avatar resolver is required because User.avatar exists but UserMapper.avatar does not */
   },
-  name: () => {
+  name: async (_parent, _arg, _ctx) => {
     /* User.name resolver is required because User.name exists but UserMapper.name does not */
   },
 };

--- a/packages/typescript-resolver-files-e2e/src/test-modules/modules/book/resolvers/Book.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-modules/modules/book/resolvers/Book.ts
@@ -1,10 +1,10 @@
 import type { BookResolvers } from './../../types.generated';
 export const Book: BookResolvers = {
   /* Implement Book resolver logic here */
-  author: () => {
+  author: async (_parent, _arg, _ctx) => {
     /* Book.author resolver is required because Book.author exists but BookMapper.author does not */
   },
-  mainGenre: () => {
+  mainGenre: async (_parent, _arg, _ctx) => {
     /* Book.mainGenre resolver is required because Book.mainGenre exists but BookMapper.mainGenre does not */
   },
 };

--- a/packages/typescript-resolver-files-e2e/src/test-modules/modules/topic/resolvers/Topic.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-modules/modules/topic/resolvers/Topic.ts
@@ -1,7 +1,7 @@
 import type { TopicResolvers } from './../../types.generated';
 export const Topic: TopicResolvers = {
   /* Implement Topic resolver logic here */
-  creator: () => {
+  creator: async (_parent, _arg, _ctx) => {
     /* Topic.creator resolver is required because Topic.creator exists but TopicMapper.creator does not */
   },
 };

--- a/packages/typescript-resolver-files-e2e/src/test-modules/modules/user/resolvers/Profile.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-modules/modules/user/resolvers/Profile.ts
@@ -1,7 +1,7 @@
 import type { ProfileResolvers } from './../../types.generated';
 export const Profile: ProfileResolvers = {
   /* Implement Profile resolver logic here */
-  user: () => {
+  user: async (_parent, _arg, _ctx) => {
     /* Profile.user resolver is required because Profile.user exists but ProfileMapper.user does not */
   },
 };

--- a/packages/typescript-resolver-files-e2e/src/test-resolver-generation/schema-full/topic/resolvers/Topic.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-resolver-generation/schema-full/topic/resolvers/Topic.ts
@@ -1,7 +1,7 @@
 import type { TopicResolvers } from './../../types.generated';
 export const Topic: TopicResolvers = {
   /* Implement Topic resolver logic here */
-  creator: () => {
+  creator: async (_parent, _arg, _ctx) => {
     /* Topic.creator resolver is required because Topic.creator exists but TopicMapper.creator does not */
   },
 };

--- a/packages/typescript-resolver-files-e2e/src/test-resolver-generation/schema-recommended/topic/resolvers/Topic.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-resolver-generation/schema-recommended/topic/resolvers/Topic.ts
@@ -1,7 +1,7 @@
 import type { TopicResolvers } from './../../types.generated';
 export const Topic: TopicResolvers = {
   /* Implement Topic resolver logic here */
-  creator: () => {
+  creator: async (_parent, _arg, _ctx) => {
     /* Topic.creator resolver is required because Topic.creator exists but TopicMapper.creator does not */
   },
 };

--- a/packages/typescript-resolver-files-e2e/src/test-scalars-module/schema-overrides/topic/resolvers/Topic.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-scalars-module/schema-overrides/topic/resolvers/Topic.ts
@@ -1,10 +1,10 @@
 import type { TopicResolvers } from './../../types.generated';
 export const Topic: TopicResolvers = {
   /* Implement Topic resolver logic here */
-  creator: () => {
+  creator: async (_parent, _arg, _ctx) => {
     /* Topic.creator resolver is required because Topic.creator exists but TopicMapper.creator does not */
   },
-  id: ({ id }) => {
+  id: ({ id }, _arg, _ctx) => {
     /* Topic.id resolver is required because Topic.id and TopicMapper.id are not compatible */
     return id;
   },

--- a/packages/typescript-resolver-files-e2e/src/test-scalars-module/schema/topic/resolvers/Topic.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-scalars-module/schema/topic/resolvers/Topic.ts
@@ -1,7 +1,7 @@
 import type { TopicResolvers } from './../../types.generated';
 export const Topic: TopicResolvers = {
   /* Implement Topic resolver logic here */
-  creator: () => {
+  creator: async (_parent, _arg, _ctx) => {
     /* Topic.creator resolver is required because Topic.creator exists but TopicMapper.creator does not */
   },
 };

--- a/packages/typescript-resolver-files/src/getGraphQLObjectTypeResolversToGenerate/getGraphQLObjectTypeResolversToGenerate.ts
+++ b/packages/typescript-resolver-files/src/getGraphQLObjectTypeResolversToGenerate/getGraphQLObjectTypeResolversToGenerate.ts
@@ -69,7 +69,7 @@ export const getGraphQLObjectTypeResolversToGenerate = ({
             if (!typeMapperProperty) {
               result[schemaType][schemaTypeProperty.name] = {
                 resolverName: schemaTypeProperty.name,
-                resolverDeclaration: `() => { /* ${schemaTypePropertyIdentifier} resolver is required because ${schemaTypePropertyIdentifier} exists but ${typeMapperPropertyIdentifier} does not */ }`,
+                resolverDeclaration: `async (_parent, _arg, _ctx) => { /* ${schemaTypePropertyIdentifier} resolver is required because ${schemaTypePropertyIdentifier} exists but ${typeMapperPropertyIdentifier} does not */ }`,
               };
               return;
             }

--- a/packages/typescript-resolver-files/src/getGraphQLObjectTypeResolversToGenerate/getGraphQLObjectTypeResolversToGenerate.ts
+++ b/packages/typescript-resolver-files/src/getGraphQLObjectTypeResolversToGenerate/getGraphQLObjectTypeResolversToGenerate.ts
@@ -85,7 +85,7 @@ export const getGraphQLObjectTypeResolversToGenerate = ({
              */
             result[schemaType][schemaTypeProperty.name] = {
               resolverName: schemaTypeProperty.name,
-              resolverDeclaration: `({ ${schemaTypeProperty.name} }) => {
+              resolverDeclaration: `({ ${schemaTypeProperty.name} }, _arg, _ctx) => {
                 /* ${schemaTypePropertyIdentifier} resolver is required because ${schemaTypePropertyIdentifier} and ${typeMapperPropertyIdentifier} are not compatible */
                 return ${schemaTypeProperty.name}
               }`,


### PR DESCRIPTION
I have found that not having the args generated for the missing resolvers when using `Mapper` types is a bit annoying since I have to add them every time and would rather them be generated but with `_` prefixes so linters don't flag them as unused args similar to how all the other resolvers are already generated.