### PR TITLE
Utilise typescript typechecker to collect properties, instead of manual implementation

### DIFF
--- a/.changeset/five-guests-marry.md
+++ b/.changeset/five-guests-marry.md
@@ -1,0 +1,9 @@
+---
+'@eddeee888/gcg-typescript-resolver-files': patch
+---
+
+Use TypeScript typechecker to collect type properties
+
+Previously, we manually walked through the program to collect properties of types. This is problematic as there are lots of ways to declare mappers that we cannot manually handle. On top of this, type property properties can be handled natively correctly by TypeScript typechecker.
+
+Note: class declaration private properties are picked up by TypeScript typechecker, which could be problematic. We are keeping that case as-is.

--- a/packages/typescript-resolver-files-e2e/src/test-modules-resolver-main-file-mode/modules/pet-domain/pet/resolvers/Pet.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-modules-resolver-main-file-mode/modules/pet-domain/pet/resolvers/Pet.ts
@@ -1,4 +1,4 @@
 import type { PetResolvers } from './../../../types.generated';
 export const Pet: PetResolvers = {
-  /* Implement Pet resolver logic here */
+  /* Implement Pet interface logic here */
 };

--- a/packages/typescript-resolver-files/src/generateResolverFiles/ensureObjectTypeResolversAreGenerated.spec.ts
+++ b/packages/typescript-resolver-files/src/generateResolverFiles/ensureObjectTypeResolversAreGenerated.spec.ts
@@ -134,6 +134,7 @@ describe('ensureObjectTypeResolversAreGenerated()', () => {
       mainImportIdentifier: 'User',
       meta: {
         moduleName: 'user',
+        relativePathFromBaseToModule: ['user'],
         normalizedResolverName: {
           base: 'User',
           withModule: 'user.User',
@@ -309,6 +310,7 @@ describe('ensureObjectTypeResolversAreGenerated()', () => {
       mainImportIdentifier: 'User',
       meta: {
         moduleName: 'user',
+        relativePathFromBaseToModule: ['user'],
         normalizedResolverName: {
           base: 'User',
           withModule: 'user.User',

--- a/packages/typescript-resolver-files/src/generateResolverFiles/getVariableStatementWithExpectedIdentifier.spec.ts
+++ b/packages/typescript-resolver-files/src/generateResolverFiles/getVariableStatementWithExpectedIdentifier.spec.ts
@@ -24,6 +24,7 @@ describe('getVariableStatementWithExpectedIdentifier()', () => {
       mainImportIdentifier: 'User',
       meta: {
         moduleName: 'user',
+        relativePathFromBaseToModule: ['user'],
         variableStatement: '',
         resolverTypeString: 'UserResolvers',
         normalizedResolverName: {
@@ -63,6 +64,7 @@ describe('getVariableStatementWithExpectedIdentifier()', () => {
       mainImportIdentifier: 'User',
       meta: {
         moduleName: 'user',
+        relativePathFromBaseToModule: ['user'],
         variableStatement: '',
         resolverTypeString: 'UserResolvers',
         normalizedResolverName: {
@@ -98,6 +100,7 @@ describe('getVariableStatementWithExpectedIdentifier()', () => {
       mainImportIdentifier: 'User',
       meta: {
         moduleName: 'user',
+        relativePathFromBaseToModule: ['user'],
         variableStatement: '',
         resolverTypeString: 'UserResolvers',
         normalizedResolverName: {

--- a/packages/typescript-resolver-files/src/getGraphQLObjectTypeResolversToGenerate/getGraphQLObjectTypeResolversToGenerate.ts
+++ b/packages/typescript-resolver-files/src/getGraphQLObjectTypeResolversToGenerate/getGraphQLObjectTypeResolversToGenerate.ts
@@ -2,6 +2,7 @@ import {
   type InterfaceDeclaration,
   type TypeAliasDeclaration,
   type SourceFile,
+  type Project,
   SyntaxKind,
 } from 'ts-morph';
 import type { TypeMappersMap } from '../parseTypeMappers';
@@ -13,10 +14,12 @@ export type GraphQLObjectTypeResolversToGenerate = Record<
 >;
 
 export const getGraphQLObjectTypeResolversToGenerate = ({
+  tsMorphProject,
   typesSourceFile,
   userDefinedSchemaObjectTypeMap,
   typeMappersMap,
 }: {
+  tsMorphProject: Project;
   typesSourceFile: SourceFile;
   typeMappersMap: TypeMappersMap;
   userDefinedSchemaObjectTypeMap: Record<string, true>;
@@ -35,7 +38,10 @@ export const getGraphQLObjectTypeResolversToGenerate = ({
     const identifier = node.getNameNode();
     const identifierName = identifier.getText();
     if (userDefinedSchemaObjectTypeMap[identifierName]) {
-      schemaTypePropertyMap[identifierName] = getNodePropertyMap(node);
+      schemaTypePropertyMap[identifierName] = getNodePropertyMap({
+        tsMorphProject,
+        node,
+      });
     }
   };
   typesSourceFile

--- a/packages/typescript-resolver-files/src/parseTypeMappers/collectTypeMappersFromSourceFile.spec.ts
+++ b/packages/typescript-resolver-files/src/parseTypeMappers/collectTypeMappersFromSourceFile.spec.ts
@@ -82,6 +82,7 @@ describe('collectTypeMappersFromSourceFile', () => {
 
     collectTypeMappersFromSourceFile(
       {
+        tsMorphProject: project,
         typeMappersSourceFile: mapperFile,
         typeMappersSuffix: 'TypeMapper',
         resolverTypesPath: '/path/to/schemas/types.generated.ts',
@@ -226,6 +227,7 @@ describe('collectTypeMappersFromSourceFile', () => {
 
     collectTypeMappersFromSourceFile(
       {
+        tsMorphProject: project,
         typeMappersSourceFile: mapperFile,
         typeMappersSuffix: 'TypeMapper',
         resolverTypesPath: '/path/to/schemas/types.generated.ts',
@@ -365,6 +367,7 @@ describe('collectTypeMappersFromSourceFile', () => {
 
     collectTypeMappersFromSourceFile(
       {
+        tsMorphProject: project,
         typeMappersSourceFile: mapperFile,
         typeMappersSuffix: 'TypeMapper',
         resolverTypesPath: '/path/to/schemas/types.generated.ts',
@@ -477,6 +480,7 @@ describe('collectTypeMappersFromSourceFile', () => {
 
     collectTypeMappersFromSourceFile(
       {
+        tsMorphProject: project,
         typeMappersSourceFile: mapperFile,
         typeMappersSuffix: 'TypeMapper',
         resolverTypesPath: '/path/to/schemas/types.generated.ts',
@@ -571,6 +575,7 @@ describe('collectTypeMappersFromSourceFile', () => {
 
     collectTypeMappersFromSourceFile(
       {
+        tsMorphProject: project,
         typeMappersSourceFile: mapperFile,
         typeMappersSuffix: 'TypeMapper',
         resolverTypesPath: '/path/to/schemas/types.generated.ts',
@@ -728,6 +733,7 @@ describe('collectTypeMappersFromSourceFile', () => {
 
     collectTypeMappersFromSourceFile(
       {
+        tsMorphProject: project,
         typeMappersSourceFile: billingMapperFile,
         typeMappersSuffix: 'TypeMapper',
         resolverTypesPath: '/path/to/schemas/types.generated.ts',
@@ -743,6 +749,7 @@ describe('collectTypeMappersFromSourceFile', () => {
 
     collectTypeMappersFromSourceFile(
       {
+        tsMorphProject: project,
         typeMappersSourceFile: addressMapperFile,
         typeMappersSuffix: 'TypeMapper',
         resolverTypesPath: '/path/to/schemas/types.generated.ts',
@@ -760,6 +767,7 @@ describe('collectTypeMappersFromSourceFile', () => {
 
     collectTypeMappersFromSourceFile(
       {
+        tsMorphProject: project,
         typeMappersSourceFile: preferenceMapperFile,
         typeMappersSuffix: 'TypeMapper',
         resolverTypesPath: '/path/to/schemas/types.generated.ts',
@@ -824,6 +832,7 @@ describe('collectTypeMappersFromSourceFile', () => {
 
     collectTypeMappersFromSourceFile(
       {
+        tsMorphProject: project,
         typeMappersSourceFile: mapperFile,
         typeMappersSuffix: 'Mapper',
         resolverTypesPath: '/path/to/schemas/types.generated.ts',
@@ -877,6 +886,7 @@ describe('collectTypeMappersFromSourceFile', () => {
 
     collectTypeMappersFromSourceFile(
       {
+        tsMorphProject: project,
         typeMappersSourceFile: project.getSourceFiles()[0],
         typeMappersSuffix: 'TypeMapper',
         resolverTypesPath: '/path/to/schemas/types.generated.ts',
@@ -889,6 +899,7 @@ describe('collectTypeMappersFromSourceFile', () => {
     expect(() =>
       collectTypeMappersFromSourceFile(
         {
+          tsMorphProject: project,
           typeMappersSourceFile: project.getSourceFiles()[1],
           typeMappersSuffix: 'TypeMapper',
           resolverTypesPath: '/path/to/schemas/types.generated.ts',

--- a/packages/typescript-resolver-files/src/parseTypeMappers/collectTypeMappersFromSourceFile.ts
+++ b/packages/typescript-resolver-files/src/parseTypeMappers/collectTypeMappersFromSourceFile.ts
@@ -4,6 +4,7 @@ import {
   type Identifier,
   type TypeAliasDeclaration,
   type InterfaceDeclaration,
+  type Project,
   Node,
   SyntaxKind,
 } from 'ts-morph';
@@ -12,12 +13,14 @@ import type { TypeMappersMap } from './parseTypeMappers';
 
 export const collectTypeMappersFromSourceFile = (
   {
+    tsMorphProject,
     typeMappersSourceFile,
     typeMappersSuffix,
     resolverTypesPath,
     shouldCollectPropertyMap,
     emitLegacyCommonJSImports,
   }: {
+    tsMorphProject: Project;
     typeMappersSourceFile: SourceFile;
     typeMappersSuffix: string;
     resolverTypesPath: string;
@@ -34,6 +37,7 @@ export const collectTypeMappersFromSourceFile = (
 
     addTypeMapperDetailsIfValid(
       {
+        tsMorphProject,
         declarationNode: interfaceDeclaration,
         identifierNode: interfaceDeclaration.getNameNode(),
         typeMappersSuffix,
@@ -56,6 +60,7 @@ export const collectTypeMappersFromSourceFile = (
 
     addTypeMapperDetailsIfValid(
       {
+        tsMorphProject,
         declarationNode: typeAlias,
         identifierNode,
         typeMappersSuffix,
@@ -83,6 +88,7 @@ export const collectTypeMappersFromSourceFile = (
 
       addTypeMapperDetailsIfValid(
         {
+          tsMorphProject,
           declarationNode: null,
           identifierNode,
           typeMappersSuffix,
@@ -108,6 +114,7 @@ export const collectTypeMappersFromSourceFile = (
 
     addTypeMapperDetailsIfValid(
       {
+        tsMorphProject,
         declarationNode: null,
         identifierNode,
         typeMappersSuffix,
@@ -123,6 +130,7 @@ export const collectTypeMappersFromSourceFile = (
 
 const addTypeMapperDetailsIfValid = (
   {
+    tsMorphProject,
     declarationNode,
     identifierNode,
     typeMappersSuffix,
@@ -131,6 +139,7 @@ const addTypeMapperDetailsIfValid = (
     shouldCollectPropertyMap,
     emitLegacyCommonJSImports,
   }: {
+    tsMorphProject: Project;
     declarationNode: InterfaceDeclaration | TypeAliasDeclaration | null;
     identifierNode: Identifier;
     typeMappersSuffix: string;
@@ -187,7 +196,10 @@ const addTypeMapperDetailsIfValid = (
       declarationNode,
       identifierNode
     );
-    typeMapperPropertyMap = getNodePropertyMap(originalDeclarationNode);
+    typeMapperPropertyMap = getNodePropertyMap({
+      node: originalDeclarationNode,
+      tsMorphProject,
+    });
   }
 
   result[schemaType] = {

--- a/packages/typescript-resolver-files/src/parseTypeMappers/parseTypeMappers.ts
+++ b/packages/typescript-resolver-files/src/parseTypeMappers/parseTypeMappers.ts
@@ -48,6 +48,7 @@ export const parseTypeMappers = ({
 
       collectTypeMappersFromSourceFile(
         {
+          tsMorphProject,
           typeMappersSourceFile,
           typeMappersSuffix,
           resolverTypesPath,

--- a/packages/typescript-resolver-files/src/preset.ts
+++ b/packages/typescript-resolver-files/src/preset.ts
@@ -143,6 +143,7 @@ export const preset: Types.OutputPreset<RawPresetConfig> = {
     const graphQLObjectTypeResolversToGenerate = await profiler.run(
       async () =>
         getGraphQLObjectTypeResolversToGenerate({
+          tsMorphProject,
           typesSourceFile,
           userDefinedSchemaObjectTypeMap:
             mergedConfig.userDefinedSchemaTypeMap.object,

--- a/packages/typescript-resolver-files/src/utils/getNodePropertyMap.spec.ts
+++ b/packages/typescript-resolver-files/src/utils/getNodePropertyMap.spec.ts
@@ -32,7 +32,9 @@ describe('getNodePropertyMap', () => {
       (node) => Node.isTypeAliasDeclaration(node) && node.getName() === 'User'
     );
 
-    expect(getNodePropertyMap(userDeclarationNode)).toEqual({
+    expect(
+      getNodePropertyMap({ tsMorphProject: project, node: userDeclarationNode })
+    ).toEqual({
       __typename: {
         name: '__typename',
       },

--- a/packages/typescript-resolver-files/src/utils/getNodePropertyMap.ts
+++ b/packages/typescript-resolver-files/src/utils/getNodePropertyMap.ts
@@ -1,9 +1,7 @@
 import {
-  type TypeNode,
-  type InterfaceDeclaration,
-  type Identifier,
+  type Project,
   type ClassDeclaration,
-  Node,
+  type Node,
   SyntaxKind,
 } from 'ts-morph';
 
@@ -13,15 +11,34 @@ export type NodePropertyMap = Record<string, { name: string }>;
  * Function to get properties of a Node in a map
  * If unable to find, returns empty object
  */
-export const getNodePropertyMap = (node: Node | undefined): NodePropertyMap => {
+export const getNodePropertyMap = ({
+  node,
+  tsMorphProject,
+}: {
+  node: Node | undefined;
+  tsMorphProject: Project;
+}): NodePropertyMap => {
   if (!node) {
     return {};
   }
 
-  const properties = getNodeProperties(node);
+  const typeChecker = tsMorphProject.getTypeChecker();
+
+  const properties = ((): string[] => {
+    if (node.isKind(SyntaxKind.ClassDeclaration)) {
+      const result: string[] = [];
+      collectClassNodeProperties(node, result);
+      return result;
+    }
+
+    return typeChecker
+      .getTypeAtLocation(node)
+      .getProperties()
+      .map((property) => property.getName());
+  })();
 
   const nodePropertyMap = properties.reduce<NodePropertyMap>(
-    (res, { propertyName }) => {
+    (res, propertyName) => {
       res[propertyName] = {
         name: propertyName,
       };
@@ -33,85 +50,9 @@ export const getNodePropertyMap = (node: Node | undefined): NodePropertyMap => {
   return nodePropertyMap;
 };
 
-type Properties = { propertyName: string }[];
-
-const getNodeProperties = (node: Node): Properties => {
-  if (node.isKind(SyntaxKind.InterfaceDeclaration)) {
-    const properties: Properties = [];
-    collectInterfaceDeclarationProperties(node, properties);
-    return properties;
-  } else if (node.isKind(SyntaxKind.TypeAliasDeclaration)) {
-    const typeNode = node.getTypeNodeOrThrow();
-    const properties: Properties = [];
-    collectTypeNodeProperties(typeNode, properties);
-    return properties;
-  } else if (node.isKind(SyntaxKind.ClassDeclaration)) {
-    const properties: Properties = [];
-    collectClassNodeProperties(node, properties);
-    return properties;
-  }
-  return [];
-};
-
-const collectInterfaceDeclarationProperties = (
-  node: InterfaceDeclaration,
-  result: Properties
-): void => {
-  // 1. Collect current node properties
-  node.getProperties().forEach((prop) => {
-    result.push({
-      propertyName: prop.getName(),
-    });
-  });
-
-  // 2. Recursively go through the extended interfaces and collect properties
-  // Interfaces can `extends` but not `implements`, so we safely target extends clauses here
-  const heritageClause = node.getHeritageClauseByKind(
-    SyntaxKind.ExtendsKeyword
-  );
-  if (heritageClause) {
-    // If `interface Dog extends BaseNode, Pet`, then `extendedIdentifiers` is `[BaseNode, Pet]`
-    const identifiers = heritageClause
-      .getTypeNodes()
-      .map((n) => n.getExpressionIfKind(SyntaxKind.Identifier))
-      .filter<Identifier>((n): n is Identifier => Boolean(n));
-
-    identifiers.forEach((n) => {
-      const parent = n.getDefinitionNodes()[0];
-      if (Node.isInterfaceDeclaration(parent)) {
-        collectInterfaceDeclarationProperties(parent, result);
-      } else {
-        // TODO: maybe log warnings here? or just throw?
-      }
-    });
-  }
-};
-
-const collectTypeNodeProperties = (
-  typeNode: TypeNode,
-  result: Properties
-): void => {
-  if (Node.isTypeLiteral(typeNode)) {
-    typeNode.getProperties().forEach((prop) => {
-      result.push({ propertyName: prop.getName() });
-    });
-  } else if (Node.isTypeReference(typeNode)) {
-    typeNode
-      .getType()
-      .getProperties()
-      .forEach((prop) => {
-        result.push({ propertyName: prop.getName() });
-      });
-  } else if (Node.isIntersectionTypeNode(typeNode)) {
-    typeNode.getTypeNodes().forEach((node) => {
-      collectTypeNodeProperties(node, result); // May contain duplicated properties from different typeNodes. Will be deduped in getNodePropertyMap.
-    });
-  }
-};
-
 const collectClassNodeProperties = (
   classNode: ClassDeclaration,
-  result: Properties
+  result: string[]
 ): void => {
   const baseClass = classNode.getBaseClass();
   if (baseClass) {
@@ -133,6 +74,6 @@ const collectClassNodeProperties = (
       // getter is skipped
       return;
     }
-    result.push({ propertyName: prop.getName() });
+    result.push(prop.getName());
   });
 };

--- a/packages/typescript-resolver-files/src/validatePresetConfig/validatePresetConfig.spec.ts
+++ b/packages/typescript-resolver-files/src/validatePresetConfig/validatePresetConfig.spec.ts
@@ -472,7 +472,7 @@ describe('validatePresetConfig - resolverGeneration', () => {
     expect(() =>
       validatePresetConfig({ resolverGeneration: 'omg_what_is_this' })
     ).toThrowError(
-      '[@eddeee888/gcg-typescript-resolver-files] ERROR: Validation - presetConfig.resolverGeneration must be "disabled", "recommended" or "full" (default is "recommended")'
+      '[@eddeee888/gcg-typescript-resolver-files] ERROR: Validation - presetConfig.resolverGeneration must be "disabled", "recommended" or "all" (default is "recommended")'
     );
   });
 });


### PR DESCRIPTION
Previously, we manually walked through the program to collect properties of types. This is problematic as there are lots of ways to declare mappers that we cannot manually handle. On top of this, type property properties can be handled natively correctly by TypeScript typechecker.

Note: class declaration private properties are picked up by TypeScript typechecker, which could be problematic. We are keeping that case as-is.