### PR TITLE
Re-configure server config to be less opinionated, move opinionated config to server preset

### DIFF
--- a/.changeset/rare-goats-pull.md
+++ b/.changeset/rare-goats-pull.md
@@ -1,0 +1,8 @@
+---
+'@eddeee888/gcg-server-config': minor
+'@eddeee888/gcg-typescript-resolver-files': patch
+---
+
+Move union and interface config from server config to server preset
+
+This config is fairly opinionated and may not make sense being on server config. However, it is definitely the default mode of operation we want to use for server preset to avoid having extra files, simplifying the setup.

--- a/packages/server-config/src/defineConfig.spec.ts
+++ b/packages/server-config/src/defineConfig.spec.ts
@@ -3,11 +3,6 @@ import { type ServerConfig, defineConfig } from './defineConfig';
 const defaultServerConfig: ServerConfig = {
   enumsAsTypes: true,
   maybeValue: 'T | null | undefined',
-  optionalResolveType: true,
-  resolversNonOptionalTypename: {
-    interfaceImplementingType: true,
-    unionMember: true,
-  },
   scalars: {
     ID: {
       input: 'string',

--- a/packages/server-config/src/defineConfig.ts
+++ b/packages/server-config/src/defineConfig.ts
@@ -14,11 +14,6 @@ export const defineConfig = (config: ServerConfig = {}): ServerConfig => {
   return {
     enumsAsTypes: true,
     maybeValue: 'T | null | undefined',
-    optionalResolveType: true,
-    resolversNonOptionalTypename: {
-      unionMember: true,
-      interfaceImplementingType: true,
-    },
     ...config,
     scalars:
       typeof configScalars === 'string'

--- a/packages/typescript-resolver-files/src/preset.ts
+++ b/packages/typescript-resolver-files/src/preset.ts
@@ -115,6 +115,11 @@ export const preset: Types.OutputPreset<RawPresetConfig> = {
 
     // typescript and typescript-resolvers plugins config
     const resolverTypesConfig = defineServerConfig({
+      optionalResolveType: true,
+      resolversNonOptionalTypename: {
+        unionMember: true,
+        interfaceImplementingType: true,
+      },
       namingConvention: 'keep',
       emitLegacyCommonJSImports,
       ...typesPluginsConfig,

--- a/yarn.lock
+++ b/yarn.lock
@@ -8153,7 +8153,7 @@ methods@~1.1.2:
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==
 
-micromatch@4.0.5, micromatch@^4.0.2, micromatch@^4.0.4, micromatch@^4.0.5:
+micromatch@4.0.5, micromatch@^4.0.0, micromatch@^4.0.2, micromatch@^4.0.4, micromatch@^4.0.5:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.5.tgz#bc8999a7cbbf77cdc89f132f6e467051b49090c6"
   integrity sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==


### PR DESCRIPTION
Union/interface usage related config options are fairly opinionated and may not make sense being on server config. However, it is definitely the default mode of operation we want to use for server preset to avoid having extra files, simplifying the setup.