### PR TITLE
Force create object types with mappers

### DIFF
--- a/.changeset/young-snails-sleep.md
+++ b/.changeset/young-snails-sleep.md
@@ -1,0 +1,5 @@
+---
+'@eddeee888/gcg-typescript-resolver-files': patch
+---
+
+Force generate object types with mappers to avoid runtime errors

--- a/packages/typescript-resolver-files-e2e/src/test-resolver-generation/schema-custom-object/resolvers.generated.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-resolver-generation/schema-custom-object/resolvers.generated.ts
@@ -1,8 +1,10 @@
 /* This file was automatically generated. DO NOT UPDATE MANUALLY. */
 import type { Resolvers } from './types.generated';
 import { Error } from './base/resolvers/Error';
+import { FeaturedUsersResult } from './user/resolvers/FeaturedUsersResult';
 import { topicEdit as Mutation_topicEdit } from './topic/resolvers/Mutation/topicEdit';
 import { Profile } from './user/resolvers/Profile';
+import { featuredUserNames as Query_featuredUserNames } from './user/resolvers/Query/featuredUserNames';
 import { me as Query_me } from './user/resolvers/Query/me';
 import { topicById as Query_topicById } from './topic/resolvers/Query/topicById';
 import { topicsCreatedByUser as Query_topicsCreatedByUser } from './topic/resolvers/Query/topicsCreatedByUser';
@@ -14,6 +16,7 @@ import { User } from './user/resolvers/User';
 import { DateTimeResolver } from 'graphql-scalars';
 export const resolvers: Resolvers = {
   Query: {
+    featuredUserNames: Query_featuredUserNames,
     me: Query_me,
     topicById: Query_topicById,
     topicsCreatedByUser: Query_topicsCreatedByUser,
@@ -22,6 +25,7 @@ export const resolvers: Resolvers = {
   Mutation: { topicEdit: Mutation_topicEdit },
   Subscription: { profileChanges: Subscription_profileChanges },
   Error: Error,
+  FeaturedUsersResult: FeaturedUsersResult,
   Profile: Profile,
   SomeRandomScalar: SomeRandomScalar,
   Topic: Topic,

--- a/packages/typescript-resolver-files-e2e/src/test-resolver-generation/schema-custom-object/typeDefs.generated.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-resolver-generation/schema-custom-object/typeDefs.generated.ts
@@ -1241,18 +1241,42 @@ export const typeDefs = {
           directives: [],
           loc: { start: 1637, end: 1690 },
         },
+        {
+          kind: 'FieldDefinition',
+          name: {
+            kind: 'Name',
+            value: 'featuredUserNames',
+            loc: { start: 1693, end: 1710 },
+          },
+          arguments: [],
+          type: {
+            kind: 'NonNullType',
+            type: {
+              kind: 'NamedType',
+              name: {
+                kind: 'Name',
+                value: 'FeaturedUsersPayload',
+                loc: { start: 1712, end: 1732 },
+              },
+              loc: { start: 1712, end: 1732 },
+            },
+            loc: { start: 1712, end: 1733 },
+          },
+          directives: [],
+          loc: { start: 1693, end: 1733 },
+        },
       ],
-      loc: { start: 1596, end: 1692 },
+      loc: { start: 1596, end: 1735 },
     },
     {
       kind: 'ObjectTypeDefinition',
-      name: { kind: 'Name', value: 'User', loc: { start: 1699, end: 1703 } },
+      name: { kind: 'Name', value: 'User', loc: { start: 1742, end: 1746 } },
       interfaces: [],
       directives: [],
       fields: [
         {
           kind: 'FieldDefinition',
-          name: { kind: 'Name', value: 'id', loc: { start: 1708, end: 1710 } },
+          name: { kind: 'Name', value: 'id', loc: { start: 1751, end: 1753 } },
           arguments: [],
           type: {
             kind: 'NonNullType',
@@ -1261,21 +1285,21 @@ export const typeDefs = {
               name: {
                 kind: 'Name',
                 value: 'ID',
-                loc: { start: 1712, end: 1714 },
+                loc: { start: 1755, end: 1757 },
               },
-              loc: { start: 1712, end: 1714 },
+              loc: { start: 1755, end: 1757 },
             },
-            loc: { start: 1712, end: 1715 },
+            loc: { start: 1755, end: 1758 },
           },
           directives: [],
-          loc: { start: 1708, end: 1715 },
+          loc: { start: 1751, end: 1758 },
         },
         {
           kind: 'FieldDefinition',
           name: {
             kind: 'Name',
             value: 'name',
-            loc: { start: 1718, end: 1722 },
+            loc: { start: 1761, end: 1765 },
           },
           arguments: [],
           type: {
@@ -1283,19 +1307,19 @@ export const typeDefs = {
             name: {
               kind: 'Name',
               value: 'String',
-              loc: { start: 1724, end: 1730 },
+              loc: { start: 1767, end: 1773 },
             },
-            loc: { start: 1724, end: 1730 },
+            loc: { start: 1767, end: 1773 },
           },
           directives: [],
-          loc: { start: 1718, end: 1730 },
+          loc: { start: 1761, end: 1773 },
         },
         {
           kind: 'FieldDefinition',
           name: {
             kind: 'Name',
             value: 'accountName',
-            loc: { start: 1733, end: 1744 },
+            loc: { start: 1776, end: 1787 },
           },
           arguments: [],
           type: {
@@ -1305,21 +1329,21 @@ export const typeDefs = {
               name: {
                 kind: 'Name',
                 value: 'String',
-                loc: { start: 1746, end: 1752 },
+                loc: { start: 1789, end: 1795 },
               },
-              loc: { start: 1746, end: 1752 },
+              loc: { start: 1789, end: 1795 },
             },
-            loc: { start: 1746, end: 1753 },
+            loc: { start: 1789, end: 1796 },
           },
           directives: [],
-          loc: { start: 1733, end: 1753 },
+          loc: { start: 1776, end: 1796 },
         },
         {
           kind: 'FieldDefinition',
           name: {
             kind: 'Name',
             value: 'accountWebsite',
-            loc: { start: 1756, end: 1770 },
+            loc: { start: 1799, end: 1813 },
           },
           arguments: [],
           type: {
@@ -1327,19 +1351,19 @@ export const typeDefs = {
             name: {
               kind: 'Name',
               value: 'String',
-              loc: { start: 1772, end: 1778 },
+              loc: { start: 1815, end: 1821 },
             },
-            loc: { start: 1772, end: 1778 },
+            loc: { start: 1815, end: 1821 },
           },
           directives: [],
-          loc: { start: 1756, end: 1778 },
+          loc: { start: 1799, end: 1821 },
         },
         {
           kind: 'FieldDefinition',
           name: {
             kind: 'Name',
             value: 'accountTwitter',
-            loc: { start: 1781, end: 1795 },
+            loc: { start: 1824, end: 1838 },
           },
           arguments: [],
           type: {
@@ -1347,59 +1371,19 @@ export const typeDefs = {
             name: {
               kind: 'Name',
               value: 'String',
-              loc: { start: 1797, end: 1803 },
+              loc: { start: 1840, end: 1846 },
             },
-            loc: { start: 1797, end: 1803 },
+            loc: { start: 1840, end: 1846 },
           },
           directives: [],
-          loc: { start: 1781, end: 1803 },
+          loc: { start: 1824, end: 1846 },
         },
         {
           kind: 'FieldDefinition',
           name: {
             kind: 'Name',
             value: 'accountGitHub',
-            loc: { start: 1806, end: 1819 },
-          },
-          arguments: [],
-          type: {
-            kind: 'NamedType',
-            name: {
-              kind: 'Name',
-              value: 'String',
-              loc: { start: 1821, end: 1827 },
-            },
-            loc: { start: 1821, end: 1827 },
-          },
-          directives: [],
-          loc: { start: 1806, end: 1827 },
-        },
-        {
-          kind: 'FieldDefinition',
-          name: {
-            kind: 'Name',
-            value: 'accountLinkedIn',
-            loc: { start: 1830, end: 1845 },
-          },
-          arguments: [],
-          type: {
-            kind: 'NamedType',
-            name: {
-              kind: 'Name',
-              value: 'String',
-              loc: { start: 1847, end: 1853 },
-            },
-            loc: { start: 1847, end: 1853 },
-          },
-          directives: [],
-          loc: { start: 1830, end: 1853 },
-        },
-        {
-          kind: 'FieldDefinition',
-          name: {
-            kind: 'Name',
-            value: 'avatar',
-            loc: { start: 1856, end: 1862 },
+            loc: { start: 1849, end: 1862 },
           },
           arguments: [],
           type: {
@@ -1412,17 +1396,57 @@ export const typeDefs = {
             loc: { start: 1864, end: 1870 },
           },
           directives: [],
-          loc: { start: 1856, end: 1870 },
+          loc: { start: 1849, end: 1870 },
+        },
+        {
+          kind: 'FieldDefinition',
+          name: {
+            kind: 'Name',
+            value: 'accountLinkedIn',
+            loc: { start: 1873, end: 1888 },
+          },
+          arguments: [],
+          type: {
+            kind: 'NamedType',
+            name: {
+              kind: 'Name',
+              value: 'String',
+              loc: { start: 1890, end: 1896 },
+            },
+            loc: { start: 1890, end: 1896 },
+          },
+          directives: [],
+          loc: { start: 1873, end: 1896 },
+        },
+        {
+          kind: 'FieldDefinition',
+          name: {
+            kind: 'Name',
+            value: 'avatar',
+            loc: { start: 1899, end: 1905 },
+          },
+          arguments: [],
+          type: {
+            kind: 'NamedType',
+            name: {
+              kind: 'Name',
+              value: 'String',
+              loc: { start: 1907, end: 1913 },
+            },
+            loc: { start: 1907, end: 1913 },
+          },
+          directives: [],
+          loc: { start: 1899, end: 1913 },
         },
       ],
-      loc: { start: 1694, end: 1872 },
+      loc: { start: 1737, end: 1915 },
     },
     {
       kind: 'ObjectTypeDefinition',
       name: {
         kind: 'Name',
         value: 'UserResult',
-        loc: { start: 1879, end: 1889 },
+        loc: { start: 1922, end: 1932 },
       },
       interfaces: [],
       directives: [],
@@ -1432,7 +1456,7 @@ export const typeDefs = {
           name: {
             kind: 'Name',
             value: 'result',
-            loc: { start: 1894, end: 1900 },
+            loc: { start: 1937, end: 1943 },
           },
           arguments: [],
           type: {
@@ -1440,22 +1464,22 @@ export const typeDefs = {
             name: {
               kind: 'Name',
               value: 'User',
-              loc: { start: 1902, end: 1906 },
+              loc: { start: 1945, end: 1949 },
             },
-            loc: { start: 1902, end: 1906 },
+            loc: { start: 1945, end: 1949 },
           },
           directives: [],
-          loc: { start: 1894, end: 1906 },
+          loc: { start: 1937, end: 1949 },
         },
       ],
-      loc: { start: 1874, end: 1908 },
+      loc: { start: 1917, end: 1951 },
     },
     {
       kind: 'UnionTypeDefinition',
       name: {
         kind: 'Name',
         value: 'UserPayload',
-        loc: { start: 1916, end: 1927 },
+        loc: { start: 1959, end: 1970 },
       },
       directives: [],
       types: [
@@ -1464,22 +1488,121 @@ export const typeDefs = {
           name: {
             kind: 'Name',
             value: 'UserResult',
-            loc: { start: 1930, end: 1940 },
+            loc: { start: 1973, end: 1983 },
           },
-          loc: { start: 1930, end: 1940 },
+          loc: { start: 1973, end: 1983 },
         },
         {
           kind: 'NamedType',
           name: {
             kind: 'Name',
             value: 'PayloadError',
-            loc: { start: 1943, end: 1955 },
+            loc: { start: 1986, end: 1998 },
           },
-          loc: { start: 1943, end: 1955 },
+          loc: { start: 1986, end: 1998 },
         },
       ],
-      loc: { start: 1910, end: 1955 },
+      loc: { start: 1953, end: 1998 },
+    },
+    {
+      kind: 'ObjectTypeDefinition',
+      name: {
+        kind: 'Name',
+        value: 'FeaturedUsersResult',
+        loc: { start: 2005, end: 2024 },
+      },
+      interfaces: [],
+      directives: [],
+      fields: [
+        {
+          kind: 'FieldDefinition',
+          name: {
+            kind: 'Name',
+            value: 'names',
+            loc: { start: 2029, end: 2034 },
+          },
+          arguments: [],
+          type: {
+            kind: 'NonNullType',
+            type: {
+              kind: 'ListType',
+              type: {
+                kind: 'NonNullType',
+                type: {
+                  kind: 'NamedType',
+                  name: {
+                    kind: 'Name',
+                    value: 'String',
+                    loc: { start: 2037, end: 2043 },
+                  },
+                  loc: { start: 2037, end: 2043 },
+                },
+                loc: { start: 2037, end: 2044 },
+              },
+              loc: { start: 2036, end: 2045 },
+            },
+            loc: { start: 2036, end: 2046 },
+          },
+          directives: [],
+          loc: { start: 2029, end: 2046 },
+        },
+        {
+          kind: 'FieldDefinition',
+          name: {
+            kind: 'Name',
+            value: 'reason',
+            loc: { start: 2049, end: 2055 },
+          },
+          arguments: [],
+          type: {
+            kind: 'NonNullType',
+            type: {
+              kind: 'NamedType',
+              name: {
+                kind: 'Name',
+                value: 'String',
+                loc: { start: 2057, end: 2063 },
+              },
+              loc: { start: 2057, end: 2063 },
+            },
+            loc: { start: 2057, end: 2064 },
+          },
+          directives: [],
+          loc: { start: 2049, end: 2064 },
+        },
+      ],
+      loc: { start: 2000, end: 2066 },
+    },
+    {
+      kind: 'UnionTypeDefinition',
+      name: {
+        kind: 'Name',
+        value: 'FeaturedUsersPayload',
+        loc: { start: 2074, end: 2094 },
+      },
+      directives: [],
+      types: [
+        {
+          kind: 'NamedType',
+          name: {
+            kind: 'Name',
+            value: 'FeaturedUsersResult',
+            loc: { start: 2097, end: 2116 },
+          },
+          loc: { start: 2097, end: 2116 },
+        },
+        {
+          kind: 'NamedType',
+          name: {
+            kind: 'Name',
+            value: 'PayloadError',
+            loc: { start: 2119, end: 2131 },
+          },
+          loc: { start: 2119, end: 2131 },
+        },
+      ],
+      loc: { start: 2068, end: 2131 },
     },
   ],
-  loc: { start: 0, end: 1956 },
+  loc: { start: 0, end: 2132 },
 } as unknown as DocumentNode;

--- a/packages/typescript-resolver-files-e2e/src/test-resolver-generation/schema-custom-object/types.generated.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-resolver-generation/schema-custom-object/types.generated.ts
@@ -3,6 +3,7 @@ import {
   GraphQLScalarType,
   GraphQLScalarTypeConfig,
 } from 'graphql';
+import { FeaturedUsersResultMapper } from './user/user.graphqls.mappers';
 import { TopicMapper } from './topic/topic.mappers';
 export type Maybe<T> = T | null | undefined;
 export type InputMaybe<T> = T | null | undefined;
@@ -50,6 +51,14 @@ export type ErrorType =
   | 'NOT_FOUND'
   | 'UNEXPECTED_ERROR';
 
+export type FeaturedUsersPayload = FeaturedUsersResult | PayloadError;
+
+export type FeaturedUsersResult = {
+  __typename?: 'FeaturedUsersResult';
+  names: Array<Scalars['String']['output']>;
+  reason: Scalars['String']['output'];
+};
+
 export type Mutation = {
   __typename?: 'Mutation';
   profileDelete: Scalars['Boolean']['output'];
@@ -90,6 +99,7 @@ export type Profile = {
 
 export type Query = {
   __typename?: 'Query';
+  featuredUserNames: FeaturedUsersPayload;
   me: UserPayload;
   topicById: TopicByIdPayload;
   topicsCreatedByUser: TopicsCreatedByUserPayload;
@@ -293,6 +303,9 @@ export type DirectiveResolverFn<
 
 /** Mapping of union types */
 export type ResolversUnionTypes<RefType extends Record<string, unknown>> = {
+  FeaturedUsersPayload:
+    | (FeaturedUsersResultMapper & { __typename: 'FeaturedUsersResult' })
+    | (PayloadError & { __typename: 'PayloadError' });
   TopicByIdPayload:
     | (PayloadError & { __typename: 'PayloadError' })
     | (Omit<TopicByIdResult, 'result'> & {
@@ -328,6 +341,11 @@ export type ResolversTypes = {
   DateTime: ResolverTypeWrapper<Scalars['DateTime']['output']>;
   Error: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['Error']>;
   ErrorType: ErrorType;
+  FeaturedUsersPayload: ResolverTypeWrapper<
+    ResolversUnionTypes<ResolversTypes>['FeaturedUsersPayload']
+  >;
+  FeaturedUsersResult: ResolverTypeWrapper<FeaturedUsersResultMapper>;
+  String: ResolverTypeWrapper<Scalars['String']['output']>;
   File: ResolverTypeWrapper<Scalars['File']['output']>;
   Mutation: ResolverTypeWrapper<{}>;
   Boolean: ResolverTypeWrapper<Scalars['Boolean']['output']>;
@@ -338,7 +356,6 @@ export type ResolversTypes = {
   Profile: ResolverTypeWrapper<Profile>;
   ID: ResolverTypeWrapper<Scalars['ID']['output']>;
   Query: ResolverTypeWrapper<{}>;
-  String: ResolverTypeWrapper<Scalars['String']['output']>;
   SomeRandomScalar: ResolverTypeWrapper<Scalars['SomeRandomScalar']['output']>;
   Subscription: ResolverTypeWrapper<{}>;
   Topic: ResolverTypeWrapper<TopicMapper>;
@@ -384,6 +401,9 @@ export type ResolversTypes = {
 export type ResolversParentTypes = {
   DateTime: Scalars['DateTime']['output'];
   Error: ResolversInterfaceTypes<ResolversParentTypes>['Error'];
+  FeaturedUsersPayload: ResolversUnionTypes<ResolversParentTypes>['FeaturedUsersPayload'];
+  FeaturedUsersResult: FeaturedUsersResultMapper;
+  String: Scalars['String']['output'];
   File: Scalars['File']['output'];
   Mutation: {};
   Boolean: Scalars['Boolean']['output'];
@@ -394,7 +414,6 @@ export type ResolversParentTypes = {
   Profile: Profile;
   ID: Scalars['ID']['output'];
   Query: {};
-  String: Scalars['String']['output'];
   SomeRandomScalar: Scalars['SomeRandomScalar']['output'];
   Subscription: {};
   Topic: TopicMapper;
@@ -433,6 +452,26 @@ export type ErrorResolvers<
 > = {
   __resolveType?: TypeResolveFn<'PayloadError', ParentType, ContextType>;
   error?: Resolver<ResolversTypes['ErrorType'], ParentType, ContextType>;
+};
+
+export type FeaturedUsersPayloadResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['FeaturedUsersPayload'] = ResolversParentTypes['FeaturedUsersPayload']
+> = {
+  __resolveType?: TypeResolveFn<
+    'FeaturedUsersResult' | 'PayloadError',
+    ParentType,
+    ContextType
+  >;
+};
+
+export type FeaturedUsersResultResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['FeaturedUsersResult'] = ResolversParentTypes['FeaturedUsersResult']
+> = {
+  names?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  reason?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export interface FileScalarConfig
@@ -490,6 +529,11 @@ export type QueryResolvers<
   ContextType = any,
   ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']
 > = {
+  featuredUserNames?: Resolver<
+    ResolversTypes['FeaturedUsersPayload'],
+    ParentType,
+    ContextType
+  >;
   me?: Resolver<ResolversTypes['UserPayload'], ParentType, ContextType>;
   topicById?: Resolver<
     ResolversTypes['TopicByIdPayload'],
@@ -669,6 +713,8 @@ export type UserResultResolvers<
 export type Resolvers<ContextType = any> = {
   DateTime?: GraphQLScalarType;
   Error?: ErrorResolvers<ContextType>;
+  FeaturedUsersPayload?: FeaturedUsersPayloadResolvers<ContextType>;
+  FeaturedUsersResult?: FeaturedUsersResultResolvers<ContextType>;
   File?: GraphQLScalarType;
   Mutation?: MutationResolvers<ContextType>;
   PaginationResult?: PaginationResultResolvers<ContextType>;

--- a/packages/typescript-resolver-files-e2e/src/test-resolver-generation/schema-custom-object/user/resolvers/FeaturedUsersResult.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-resolver-generation/schema-custom-object/user/resolvers/FeaturedUsersResult.ts
@@ -1,0 +1,18 @@
+import type { FeaturedUsersResultResolvers } from './../../types.generated';
+/*
+ * WARNING
+ * This object type is NOT supposed to be generated because it is in the `resolverGeneration.object: "!*Result,!*Error"` ignore pattern.
+ *
+ * However, it is generated because "FeaturedUsersResultMapper" is declared. This is to ensure runtime safety.
+ * When a mapper is used, it is possible to hit runtime errors in some senarios:
+ * - given a field name, the schema type's field type does not match mapper's field type
+ * - a schema type's field does not exist in the mapper's fields
+ *
+ * If you want to skip this generation, remove the mapper or update the ignore pattern in the config.
+ */
+export const FeaturedUsersResult: FeaturedUsersResultResolvers = {
+  /* Implement FeaturedUsersResult resolver logic here */
+  names: async (_parent, _arg, _ctx) => {
+    /* FeaturedUsersResult.names resolver is required because FeaturedUsersResult.names exists but FeaturedUsersResultMapper.names does not */
+  },
+};

--- a/packages/typescript-resolver-files-e2e/src/test-resolver-generation/schema-custom-object/user/resolvers/Query/featuredUserNames.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-resolver-generation/schema-custom-object/user/resolvers/Query/featuredUserNames.ts
@@ -1,0 +1,6 @@
+import type { QueryResolvers } from './../../../types.generated';
+export const featuredUserNames: NonNullable<
+  QueryResolvers['featuredUserNames']
+> = async (_parent, _arg, _ctx) => {
+  /* Implement Query.featuredUserNames resolver logic here */
+};

--- a/packages/typescript-resolver-files-e2e/src/test-resolver-generation/schema-custom-object/user/user.graphqls.mappers.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-resolver-generation/schema-custom-object/user/user.graphqls.mappers.ts
@@ -1,0 +1,4 @@
+export type FeaturedUsersResultMapper = {
+  userIds: string[];
+  reason: string;
+};

--- a/packages/typescript-resolver-files-e2e/src/test-resolver-generation/schema-custom-object/user/user.graphqls.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-resolver-generation/schema-custom-object/user/user.graphqls.ts
@@ -4,6 +4,7 @@ export const userTypeDefs = gql`
   extend type Query {
     me: UserPayload!
     userByAccountName(accountName: String!): UserPayload!
+    featuredUserNames: FeaturedUsersPayload!
   }
 
   type User {
@@ -22,4 +23,11 @@ export const userTypeDefs = gql`
   }
 
   union UserPayload = UserResult | PayloadError
+
+  type FeaturedUsersResult {
+    names: [String!]!
+    reason: String!
+  }
+
+  union FeaturedUsersPayload = FeaturedUsersResult | PayloadError
 `;

--- a/packages/typescript-resolver-files-e2e/src/test-resolver-generation/schema-disabled/resolvers.generated.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-resolver-generation/schema-disabled/resolvers.generated.ts
@@ -1,6 +1,8 @@
 /* This file was automatically generated. DO NOT UPDATE MANUALLY. */
 import type { Resolvers } from './types.generated';
+import { Topic } from './topic/resolvers/Topic';
 import { DateTimeResolver } from 'graphql-scalars';
 export const resolvers: Resolvers = {
+  Topic: Topic,
   DateTime: DateTimeResolver,
 };

--- a/packages/typescript-resolver-files-e2e/src/test-resolver-generation/schema-disabled/topic/resolvers/Topic.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-resolver-generation/schema-disabled/topic/resolvers/Topic.ts
@@ -1,0 +1,18 @@
+import type { TopicResolvers } from './../../types.generated';
+/*
+ * WARNING
+ * This object type is NOT supposed to be generated because it is in the `resolverGeneration.object: ""` ignore pattern.
+ *
+ * However, it is generated because "TopicMapper" is declared. This is to ensure runtime safety.
+ * When a mapper is used, it is possible to hit runtime errors in some senarios:
+ * - given a field name, the schema type's field type does not match mapper's field type
+ * - a schema type's field does not exist in the mapper's fields
+ *
+ * If you want to skip this generation, remove the mapper or update the ignore pattern in the config.
+ */
+export const Topic: TopicResolvers = {
+  /* Implement Topic resolver logic here */
+  creator: async (_parent, _arg, _ctx) => {
+    /* Topic.creator resolver is required because Topic.creator exists but TopicMapper.creator does not */
+  },
+};

--- a/packages/typescript-resolver-files/src/generateResolverFiles/handleGraphQLObjectType.ts
+++ b/packages/typescript-resolver-files/src/generateResolverFiles/handleGraphQLObjectType.ts
@@ -48,10 +48,12 @@ export const handleGraphQLObjectType: GraphQLTypeHandler<
       );
       return `/*
     * WARNING
-    * This object type is NOT supposed to be generated because it is in the "${resolverGeneration.object}" ignore pattern.
+    * This object type is NOT supposed to be generated because it is in the \`resolverGeneration.object: "${resolverGeneration.object}"\` ignore pattern.
     *
     * However, it is generated because "${mapperDetails.typeMapperName}" is declared. This is to ensure runtime safety.
-    * When a mapper is used, it is possible to hit runtime errors if a mapper's field does not match the schema's field type.
+    * When a mapper is used, it is possible to hit runtime errors in some senarios:
+    * - given a field name, the schema type's field type does not match mapper's field type
+    * - a schema type's field does not exist in the mapper's fields
     *
     * If you want to skip this generation, remove the mapper or update the ignore pattern in the config.
     */\n`;

--- a/packages/typescript-resolver-files/src/generateResolverFiles/handleGraphQLObjectType.ts
+++ b/packages/typescript-resolver-files/src/generateResolverFiles/handleGraphQLObjectType.ts
@@ -22,22 +22,42 @@ export const handleGraphQLObjectType: GraphQLTypeHandler<
     result,
     config: {
       resolverGeneration,
+      typeMappersMap,
       graphQLObjectTypeResolversToGenerate,
       emitLegacyCommonJSImports,
     },
   }
 ) => {
-  if (
-    !isMatchResolverNamePattern({
-      pattern: resolverGeneration.object,
-      value: normalizedResolverName.withModule,
-    })
-  ) {
+  const matchedPatternToGenerate = isMatchResolverNamePattern({
+    pattern: resolverGeneration.object,
+    value: normalizedResolverName.withModule,
+  });
+  const mapperDetails = typeMappersMap[normalizedResolverName.base];
+
+  if (!matchedPatternToGenerate && !mapperDetails) {
     logger.debug(
       `Skipped Object resolver generation: "${normalizedResolverName.withModule}". "Pattern: ${resolverGeneration.object}".`
     );
     return;
   }
+
+  const forcedGenerationWarning = (() => {
+    if (!matchedPatternToGenerate && mapperDetails) {
+      logger.warn(
+        `Object resolver generation was NOT skipped because there is a associated mapper: "${normalizedResolverName.withModule}". "Pattern: ${resolverGeneration.object}". Mapper: ${mapperDetails.typeMapperName}`
+      );
+      return `/*
+    * WARNING
+    * This object type is NOT supposed to be generated because it is in the "${resolverGeneration.object}" ignore pattern.
+    *
+    * However, it is generated because "${mapperDetails.typeMapperName}" is declared. This is to ensure runtime safety.
+    * When a mapper is used, it is possible to hit runtime errors if a mapper's field does not match the schema's field type.
+    *
+    * If you want to skip this generation, remove the mapper or update the ignore pattern in the config.
+    */\n`;
+    }
+    return '';
+  })();
 
   if (fieldsToPick.length > 0 && pickReferenceResolver) {
     fieldsToPick.push('__resolveReference');
@@ -69,7 +89,7 @@ export const handleGraphQLObjectType: GraphQLTypeHandler<
         )
       : allResolversToGenerate;
 
-  const variableStatement = `export const ${resolverName}: ${typeString} = {
+  const variableStatement = `${forcedGenerationWarning}export const ${resolverName}: ${typeString} = {
     /* Implement ${resolverName} resolver logic here */
   };`;
 

--- a/packages/typescript-resolver-files/src/generateResolverFiles/types.ts
+++ b/packages/typescript-resolver-files/src/generateResolverFiles/types.ts
@@ -1,6 +1,7 @@
 import type { GraphQLSchema } from 'graphql';
 import type { SourceFile, Project } from 'ts-morph';
 import type { GraphQLObjectTypeResolversToGenerate } from '../getGraphQLObjectTypeResolversToGenerate';
+import type { TypeMappersMap } from '../parseTypeMappers';
 import type { ParseSourcesResult } from '../parseSources';
 import type { ImportLineMeta, RootObjectType } from '../utils';
 import type { ParsedPresetConfig } from '../validatePresetConfig';
@@ -74,6 +75,7 @@ export interface GenerateResolverFilesContext {
       project: Project;
       typesSourceFile: SourceFile;
     };
+    typeMappersMap: TypeMappersMap;
     graphQLObjectTypeResolversToGenerate: GraphQLObjectTypeResolversToGenerate;
     fixObjectTypeResolvers: ParsedPresetConfig['fixObjectTypeResolvers'];
     emitLegacyCommonJSImports: boolean;

--- a/packages/typescript-resolver-files/src/preset.ts
+++ b/packages/typescript-resolver-files/src/preset.ts
@@ -223,6 +223,7 @@ export const preset: Types.OutputPreset<RawPresetConfig> = {
             resolverMainFile,
             resolverMainFileMode,
             resolverGeneration,
+            typeMappersMap,
             graphQLObjectTypeResolversToGenerate,
             tsMorph: {
               project: tsMorphProject,


### PR DESCRIPTION
When a mapper is used, it is possible to hit runtime errors in some senarios:
- given a field name, the schema type's field type does not match mapper's field type
- a schema type's field does not exist in the mapper's fields

Therefore, when an object type mapper is provided, we should force generate the resolver to help users avoid runtime errors.