### PR TITLE
Update README.md Missing enum for resolverGeneration

### DIFF
--- a/packages/typescript-resolver-files/README.md
+++ b/packages/typescript-resolver-files/README.md
@@ -158,6 +158,7 @@ Internally, each string option is turned into an object. This object uses glob p
   object: '*',
   union: '',
   interface: '',
+  enum: '',
 }
 ```
 


### PR DESCRIPTION
`enum`-property was missing in README for `resolverGeneration === 'recommended'`

(Value from validatePresetConfig.ts:384)