### PR TITLE
Fix runtime error for complex synth generics e.g. kysely wrappers

### DIFF
--- a/.changeset/polite-numbers-love.md
+++ b/.changeset/polite-numbers-love.md
@@ -1,0 +1,11 @@
+---
+'@eddeee888/gcg-typescript-resolver-files': patch
+---
+
+Avoid low-level TypeScript typechecker usage unncessarily, which breaks when running static analysis
+
+Originally, `getType` function was called during static analysis to get low-level `Type` for each type property declarations. These types can be used in typechecker's `isAssignableTo` function, which would have a significant perf boost (if done right). However, there needs to be a significant change to use `.isAssignableTo`, so `getType` was left there so we can continue the work later.
+
+However, declarations of a node could be `undefined` if the type is wrapped in generics that synthesies properties(?). This causes the runtime error. [Relevant convo](https://github.com/microsoft/TypeScript/issues/61697)
+
+For now, we can just remove the `getType` call, until we know how to handle these typing issues.

--- a/packages/typescript-resolver-files-e2e/project.json
+++ b/packages/typescript-resolver-files-e2e/project.json
@@ -158,6 +158,13 @@
             "rimraf -g \"packages/typescript-resolver-files-e2e/src/test-deep-modules/**/generated\""
           ],
           "parallel": false
+        },
+        "test-complex-synth-generic-wrapper": {
+          "commands": [
+            "rimraf -g \"packages/typescript-resolver-files-e2e/src/test-complex-synth-generic-wrapper/**/resolvers/\"",
+            "rimraf -g \"packages/typescript-resolver-files-e2e/src/test-complex-synth-generic-wrapper/**/*.generated.*\""
+          ],
+          "parallel": false
         }
       }
     },
@@ -183,7 +190,8 @@
           "nx graphql-codegen typescript-resolver-files-e2e -c test-nested-domain-modules --verbose",
           "nx graphql-codegen typescript-resolver-files-e2e -c test-resolvers-auto-wireup --verbose",
           "nx graphql-codegen typescript-resolver-files-e2e -c test-federation --verbose",
-          "nx graphql-codegen typescript-resolver-files-e2e -c test-deep-modules --verbose"
+          "nx graphql-codegen typescript-resolver-files-e2e -c test-deep-modules --verbose",
+          "nx graphql-codegen typescript-resolver-files-e2e -c test-complex-synth-generic-wrapper --verbose"
         ],
         "parallel": false
       },
@@ -258,6 +266,9 @@
         },
         "test-deep-modules": {
           "configFile": "packages/typescript-resolver-files-e2e/src/test-deep-modules/codegen.ts"
+        },
+        "test-complex-synth-generic-wrapper": {
+          "configFile": "packages/typescript-resolver-files-e2e/src/test-complex-synth-generic-wrapper/codegen.ts"
         }
       },
       "dependsOn": ["prepare-e2e-modules"]

--- a/packages/typescript-resolver-files-e2e/src/test-complex-synth-generic-wrapper/codegen.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-complex-synth-generic-wrapper/codegen.ts
@@ -1,0 +1,22 @@
+import type { CodegenConfig } from '@graphql-codegen/cli';
+import { defineConfig } from '@eddeee888/gcg-typescript-resolver-files';
+
+const config: CodegenConfig = {
+  hooks: {
+    afterAllFileWrite: ['prettier --write'],
+  },
+  generates: {
+    'packages/typescript-resolver-files-e2e/src/test-complex-synth-generic-wrapper/schema':
+      defineConfig(
+        { resolverGeneration: 'minimal' },
+        {
+          schema: [
+            'packages/typescript-resolver-files-e2e/src/test-complex-synth-generic-wrapper/**/*.graphqls',
+            'packages/typescript-resolver-files-e2e/src/test-complex-synth-generic-wrapper/**/*.graphqls.ts',
+          ],
+        }
+      ),
+  },
+};
+
+export default config;

--- a/packages/typescript-resolver-files-e2e/src/test-complex-synth-generic-wrapper/schema/base/base.graphqls
+++ b/packages/typescript-resolver-files-e2e/src/test-complex-synth-generic-wrapper/schema/base/base.graphqls
@@ -1,0 +1,10 @@
+type Query {
+  book(id: ID!): Book
+}
+
+type Book {
+  id: ID!
+  isbn: String!
+  nextBookInSeries: Book
+  previousBookInSeries: Book
+}

--- a/packages/typescript-resolver-files-e2e/src/test-complex-synth-generic-wrapper/schema/base/base.mappers.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-complex-synth-generic-wrapper/schema/base/base.mappers.ts
@@ -1,0 +1,30 @@
+// Start: types from kysely
+type Generated<S> = ColumnType<S, S | undefined, S>;
+type ColumnType<
+  SelectType,
+  InsertType = SelectType,
+  UpdateType = SelectType
+> = {
+  readonly __select__: SelectType;
+  readonly __insert__: InsertType;
+  readonly __update__: UpdateType;
+};
+type DrainOuterGeneric<T> = [T] extends [unknown] ? T : never;
+type IfNotNever<T, K> = T extends never ? never : K;
+type SelectType<T> = T extends ColumnType<infer S, any, any> ? S : T;
+type NonNeverSelectKeys<R> = {
+  [K in keyof R]: IfNotNever<SelectType<R[K]>, K>;
+}[keyof R];
+type Selectable<R> = DrainOuterGeneric<{
+  [K in NonNeverSelectKeys<R>]: SelectType<R[K]>;
+}>;
+// End: types from kysely
+
+interface BookTable {
+  id: Generated<number>;
+  isbn: string;
+  next_book_in_series_id: number | null;
+  previous_book_in_series_id: number | null;
+}
+
+export type BookMapper = Selectable<BookTable>;

--- a/packages/typescript-resolver-files-e2e/src/test-complex-synth-generic-wrapper/schema/base/resolvers/Book.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-complex-synth-generic-wrapper/schema/base/resolvers/Book.ts
@@ -1,0 +1,19 @@
+import type { BookResolvers } from './../../types.generated';
+/*
+ * Note: This object type is generated because "BookMapper" is declared. This is to ensure runtime safety.
+ *
+ * When a mapper is used, it is possible to hit runtime errors in some scenarios:
+ * - given a field name, the schema type's field type does not match mapper's field type
+ * - or a schema type's field does not exist in the mapper's fields
+ *
+ * If you want to skip this file generation, remove the mapper or update the pattern in the `resolverGeneration.object` config.
+ */
+export const Book: BookResolvers = {
+  /* Implement Book resolver logic here */
+  nextBookInSeries: async (_parent, _arg, _ctx) => {
+    /* Book.nextBookInSeries resolver is required because Book.nextBookInSeries exists but BookMapper.nextBookInSeries does not */
+  },
+  previousBookInSeries: async (_parent, _arg, _ctx) => {
+    /* Book.previousBookInSeries resolver is required because Book.previousBookInSeries exists but BookMapper.previousBookInSeries does not */
+  },
+};

--- a/packages/typescript-resolver-files-e2e/src/test-complex-synth-generic-wrapper/schema/base/resolvers/Query/book.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-complex-synth-generic-wrapper/schema/base/resolvers/Query/book.ts
@@ -1,0 +1,8 @@
+import type { QueryResolvers } from './../../../types.generated';
+export const book: NonNullable<QueryResolvers['book']> = async (
+  _parent,
+  _arg,
+  _ctx
+) => {
+  /* Implement Query.book resolver logic here */
+};

--- a/packages/typescript-resolver-files-e2e/src/test-complex-synth-generic-wrapper/schema/resolvers.generated.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-complex-synth-generic-wrapper/schema/resolvers.generated.ts
@@ -1,0 +1,9 @@
+/* This file was automatically generated. DO NOT UPDATE MANUALLY. */
+import type { Resolvers } from './types.generated';
+import { book as Query_book } from './base/resolvers/Query/book';
+import { Book } from './base/resolvers/Book';
+export const resolvers: Resolvers = {
+  Query: { book: Query_book },
+
+  Book: Book,
+};

--- a/packages/typescript-resolver-files-e2e/src/test-complex-synth-generic-wrapper/schema/schema.generated.graphqls
+++ b/packages/typescript-resolver-files-e2e/src/test-complex-synth-generic-wrapper/schema/schema.generated.graphqls
@@ -1,0 +1,10 @@
+type Book {
+  id: ID!
+  isbn: String!
+  nextBookInSeries: Book
+  previousBookInSeries: Book
+}
+
+type Query {
+  book(id: ID!): Book
+}

--- a/packages/typescript-resolver-files-e2e/src/test-complex-synth-generic-wrapper/schema/typeDefs.generated.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-complex-synth-generic-wrapper/schema/typeDefs.generated.ts
@@ -1,0 +1,89 @@
+import type { DocumentNode } from 'graphql';
+export const typeDefs = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'ObjectTypeDefinition',
+      name: { kind: 'Name', value: 'Query' },
+      interfaces: [],
+      directives: [],
+      fields: [
+        {
+          kind: 'FieldDefinition',
+          name: { kind: 'Name', value: 'book' },
+          arguments: [
+            {
+              kind: 'InputValueDefinition',
+              name: { kind: 'Name', value: 'id' },
+              type: {
+                kind: 'NonNullType',
+                type: {
+                  kind: 'NamedType',
+                  name: { kind: 'Name', value: 'ID' },
+                },
+              },
+              directives: [],
+            },
+          ],
+          type: { kind: 'NamedType', name: { kind: 'Name', value: 'Book' } },
+          directives: [],
+        },
+      ],
+    },
+    {
+      kind: 'ObjectTypeDefinition',
+      name: { kind: 'Name', value: 'Book' },
+      interfaces: [],
+      directives: [],
+      fields: [
+        {
+          kind: 'FieldDefinition',
+          name: { kind: 'Name', value: 'id' },
+          arguments: [],
+          type: {
+            kind: 'NonNullType',
+            type: { kind: 'NamedType', name: { kind: 'Name', value: 'ID' } },
+          },
+          directives: [],
+        },
+        {
+          kind: 'FieldDefinition',
+          name: { kind: 'Name', value: 'isbn' },
+          arguments: [],
+          type: {
+            kind: 'NonNullType',
+            type: {
+              kind: 'NamedType',
+              name: { kind: 'Name', value: 'String' },
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: 'FieldDefinition',
+          name: { kind: 'Name', value: 'nextBookInSeries' },
+          arguments: [],
+          type: { kind: 'NamedType', name: { kind: 'Name', value: 'Book' } },
+          directives: [],
+        },
+        {
+          kind: 'FieldDefinition',
+          name: { kind: 'Name', value: 'previousBookInSeries' },
+          arguments: [],
+          type: { kind: 'NamedType', name: { kind: 'Name', value: 'Book' } },
+          directives: [],
+        },
+      ],
+    },
+    {
+      kind: 'SchemaDefinition',
+      operationTypes: [
+        {
+          kind: 'OperationTypeDefinition',
+          type: { kind: 'NamedType', name: { kind: 'Name', value: 'Query' } },
+          operation: 'query',
+        },
+      ],
+    },
+  ],
+} as unknown as DocumentNode;

--- a/packages/typescript-resolver-files-e2e/src/test-complex-synth-generic-wrapper/schema/types.generated.ts
+++ b/packages/typescript-resolver-files-e2e/src/test-complex-synth-generic-wrapper/schema/types.generated.ts
@@ -1,0 +1,209 @@
+import { GraphQLResolveInfo } from 'graphql';
+import { BookMapper } from './base/base.mappers';
+export type Maybe<T> = T | null | undefined;
+export type InputMaybe<T> = T | null | undefined;
+export type Exact<T extends { [key: string]: unknown }> = {
+  [K in keyof T]: T[K];
+};
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
+  [SubKey in K]?: Maybe<T[SubKey]>;
+};
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
+  [SubKey in K]: Maybe<T[SubKey]>;
+};
+export type MakeEmpty<
+  T extends { [key: string]: unknown },
+  K extends keyof T
+> = { [_ in K]?: never };
+export type Incremental<T> =
+  | T
+  | {
+      [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never;
+    };
+export type RequireFields<T, K extends keyof T> = Omit<T, K> & {
+  [P in K]-?: NonNullable<T[P]>;
+};
+/** All built-in and custom scalars, mapped to their actual values */
+export type Scalars = {
+  ID: { input: string; output: string | number };
+  String: { input: string; output: string };
+  Boolean: { input: boolean; output: boolean };
+  Int: { input: number; output: number };
+  Float: { input: number; output: number };
+};
+
+export type Book = {
+  __typename?: 'Book';
+  id: Scalars['ID']['output'];
+  isbn: Scalars['String']['output'];
+  nextBookInSeries?: Maybe<Book>;
+  previousBookInSeries?: Maybe<Book>;
+};
+
+export type Query = {
+  __typename?: 'Query';
+  book?: Maybe<Book>;
+};
+
+export type QuerybookArgs = {
+  id: Scalars['ID']['input'];
+};
+
+export type ResolverTypeWrapper<T> = Promise<T> | T;
+
+export type ResolverWithResolve<TResult, TParent, TContext, TArgs> = {
+  resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
+};
+export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> =
+  | ResolverFn<TResult, TParent, TContext, TArgs>
+  | ResolverWithResolve<TResult, TParent, TContext, TArgs>;
+
+export type ResolverFn<TResult, TParent, TContext, TArgs> = (
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => Promise<TResult> | TResult;
+
+export type SubscriptionSubscribeFn<TResult, TParent, TContext, TArgs> = (
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => AsyncIterable<TResult> | Promise<AsyncIterable<TResult>>;
+
+export type SubscriptionResolveFn<TResult, TParent, TContext, TArgs> = (
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => TResult | Promise<TResult>;
+
+export interface SubscriptionSubscriberObject<
+  TResult,
+  TKey extends string,
+  TParent,
+  TContext,
+  TArgs
+> {
+  subscribe: SubscriptionSubscribeFn<
+    { [key in TKey]: TResult },
+    TParent,
+    TContext,
+    TArgs
+  >;
+  resolve?: SubscriptionResolveFn<
+    TResult,
+    { [key in TKey]: TResult },
+    TContext,
+    TArgs
+  >;
+}
+
+export interface SubscriptionResolverObject<TResult, TParent, TContext, TArgs> {
+  subscribe: SubscriptionSubscribeFn<any, TParent, TContext, TArgs>;
+  resolve: SubscriptionResolveFn<TResult, any, TContext, TArgs>;
+}
+
+export type SubscriptionObject<
+  TResult,
+  TKey extends string,
+  TParent,
+  TContext,
+  TArgs
+> =
+  | SubscriptionSubscriberObject<TResult, TKey, TParent, TContext, TArgs>
+  | SubscriptionResolverObject<TResult, TParent, TContext, TArgs>;
+
+export type SubscriptionResolver<
+  TResult,
+  TKey extends string,
+  TParent = {},
+  TContext = {},
+  TArgs = {}
+> =
+  | ((
+      ...args: any[]
+    ) => SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>)
+  | SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>;
+
+export type TypeResolveFn<TTypes, TParent = {}, TContext = {}> = (
+  parent: TParent,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => Maybe<TTypes> | Promise<Maybe<TTypes>>;
+
+export type IsTypeOfResolverFn<T = {}, TContext = {}> = (
+  obj: T,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => boolean | Promise<boolean>;
+
+export type NextResolverFn<T> = () => Promise<T>;
+
+export type DirectiveResolverFn<
+  TResult = {},
+  TParent = {},
+  TContext = {},
+  TArgs = {}
+> = (
+  next: NextResolverFn<TResult>,
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => TResult | Promise<TResult>;
+
+/** Mapping between all available schema types and the resolvers types */
+export type ResolversTypes = {
+  Book: ResolverTypeWrapper<BookMapper>;
+  ID: ResolverTypeWrapper<Scalars['ID']['output']>;
+  String: ResolverTypeWrapper<Scalars['String']['output']>;
+  Query: ResolverTypeWrapper<{}>;
+  Boolean: ResolverTypeWrapper<Scalars['Boolean']['output']>;
+};
+
+/** Mapping between all available schema types and the resolvers parents */
+export type ResolversParentTypes = {
+  Book: BookMapper;
+  ID: Scalars['ID']['output'];
+  String: Scalars['String']['output'];
+  Query: {};
+  Boolean: Scalars['Boolean']['output'];
+};
+
+export type BookResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['Book'] = ResolversParentTypes['Book']
+> = {
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  isbn?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  nextBookInSeries?: Resolver<
+    Maybe<ResolversTypes['Book']>,
+    ParentType,
+    ContextType
+  >;
+  previousBookInSeries?: Resolver<
+    Maybe<ResolversTypes['Book']>,
+    ParentType,
+    ContextType
+  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type QueryResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']
+> = {
+  book?: Resolver<
+    Maybe<ResolversTypes['Book']>,
+    ParentType,
+    ContextType,
+    RequireFields<QuerybookArgs, 'id'>
+  >;
+};
+
+export type Resolvers<ContextType = any> = {
+  Book?: BookResolvers<ContextType>;
+  Query?: QueryResolvers<ContextType>;
+};

--- a/packages/typescript-resolver-files/src/getGraphQLObjectTypeResolversToGenerate/getNodePropertyMap.spec.ts
+++ b/packages/typescript-resolver-files/src/getGraphQLObjectTypeResolversToGenerate/getNodePropertyMap.spec.ts
@@ -38,29 +38,18 @@ describe('getNodePropertyMap', () => {
     });
 
     expect(nodePropertyMap.__typename.name).toBe('__typename');
-    expect(nodePropertyMap.__typename.type.getText()).toBe('"User"');
 
     expect(nodePropertyMap.accountGitHub.name).toBe('accountGitHub');
-    expect(nodePropertyMap.accountGitHub.type.getText()).toBe('string');
 
     expect(nodePropertyMap.accountGoogle.name).toBe('accountGoogle');
-    expect(nodePropertyMap.accountGoogle.type.getText()).toBe('string');
 
     expect(nodePropertyMap.createdAt.name).toBe('createdAt');
-    expect(nodePropertyMap.createdAt.type.getText()).toBe(
-      'string | number | Date'
-    );
 
     expect(nodePropertyMap.fullName.name).toBe('fullName');
-    expect(nodePropertyMap.fullName.type.getText()).toBe('string');
 
     expect(nodePropertyMap.id.name).toBe('id');
-    expect(nodePropertyMap.id.type.getText()).toBe('string');
 
     expect(nodePropertyMap.role.name).toBe('role');
-    expect(nodePropertyMap.role.type.getText()).toBe(
-      'import("/path/to/types.generated").UserRole'
-    );
   });
 
   it('correctly resolves property map a class', () => {
@@ -98,12 +87,8 @@ describe('getNodePropertyMap', () => {
     expect(nodePropertyMap.word2).toBe(undefined);
 
     expect(nodePropertyMap.name.name).toBe('name');
-    expect(nodePropertyMap.name.type.getText()).toBe('string');
 
     expect(nodePropertyMap.role.name).toBe('role');
-    expect(nodePropertyMap.role.type.getText()).toBe(
-      'import("/path/to/types").UserRole'
-    );
   });
 
   it('correctly resolves property map a type alias mapper', () => {
@@ -131,12 +116,9 @@ describe('getNodePropertyMap', () => {
     });
 
     expect(nodePropertyMap.id.name).toBe('id');
-    expect(nodePropertyMap.id.type.getText()).toBe('number');
 
     expect(nodePropertyMap.name.name).toBe('name');
-    expect(nodePropertyMap.name.type.getText()).toBe('string');
 
     expect(nodePropertyMap.role.name).toBe('role');
-    expect(nodePropertyMap.role.type.getText()).toBe('UserRole'); // Non-exported types will have result in the name, not the `import("/path/to/mappers")` path
   });
 });

--- a/packages/typescript-resolver-files/src/getGraphQLObjectTypeResolversToGenerate/getNodePropertyMap.ts
+++ b/packages/typescript-resolver-files/src/getGraphQLObjectTypeResolversToGenerate/getNodePropertyMap.ts
@@ -2,11 +2,10 @@ import {
   type Project,
   type ClassDeclaration,
   type Node,
-  type Type,
   SyntaxKind,
 } from 'ts-morph';
 
-type NodePropertyMapValue = { type: Type; name: string };
+type NodePropertyMapValue = { name: string };
 export type NodePropertyMap = Record<string, NodePropertyMapValue>;
 
 /**
@@ -38,16 +37,14 @@ export const getNodePropertyMap = ({
       .getProperties()
       .map((prop) => {
         return {
-          type: prop.getDeclarations()[0].getType(),
           name: prop.getName(),
         };
       });
   })();
 
   const nodePropertyMap = properties.reduce<NodePropertyMap>(
-    (res, { type, name }) => {
+    (res, { name }) => {
       res[name] = {
-        type,
         name,
       };
       return res;
@@ -83,7 +80,6 @@ const collectClassNodeProperties = (
       return;
     }
     result.push({
-      type: prop.getType(),
       name: prop.getName(),
     });
   });


### PR DESCRIPTION
Related: https://github.com/eddeee888/graphql-code-generator-plugins/issues/360

Originally, `getType` function was called during static analysis to get low-level `Type` for each type property declarations. These types can be used in typechecker's `isAssignableTo` function, which would have a significant perf boost (if done right). However, there needs to be a significant change to use `.isAssignableTo`, so `getType` was left there so we can continue the work later.

However, declarations of a node could be `undefined` if the type is wrapped in generics that synthesies properties(?). This causes the runtime error. [Relevant convo](https://github.com/microsoft/TypeScript/issues/61697)

For now, we can just remove the `getType` call, until we know how to handle these typing issues.