### PR TITLE
Filter empty files to prevent GraphQL codegen plugin configuration errors

### DIFF
--- a/packages/operation-location-migration/src/preset.ts
+++ b/packages/operation-location-migration/src/preset.ts
@@ -346,7 +346,9 @@ export const preset: Types.OutputPreset<TypedPresetConfig> = {
       );
     });
 
-    return tsProject.getSourceFiles().map((tsSourceFile) => {
+    return tsProject.getSourceFiles()
+    .filter((sf) => sf.getFullText().trim().length > 0)
+    .map((tsSourceFile) => {
       return {
         filename: tsSourceFile.getFilePath(),
         pluginMap: { add: addPlugin },


### PR DESCRIPTION
# Fix GraphQL Codegen Plugin Configuration Issues
## Issue
The GraphQL codegen was failing if files included in tsconfig were empty:
**Invalid plugin configuration**: Empty source files were being processed, causing the `add` plugin to fail with:
   ```
   Configuration provided for 'add' plugin is invalid: "content" is missing!
   ```
## Solution
### ✅ Filter out empty source files  
- Added `.filter()` to skip files with no meaningful content before processing
- Prevents invalid plugin configurations from empty files
```typescript
return tsProject.getSourceFiles()
  .filter((sf) => sf.getFullText().trim().length > 0)  // ← just add a filter for empty files
  .map((tsSourceFile) => ({
    filename: tsSourceFile.getFilePath(),
    pluginMap: { add: addPlugin },  // ← Fixed reference
    plugins: [{ add: { content: tsSourceFile.getFullText() } }],
    config: {},
    schema,
    documents: [],
  }));
```
## Results
- ✅ Prevents empty/invalid plugin outputs  
- ✅ **Tested locally** with both `src/test/*.tsx` and `src/**/*.tsx` includes — codegen now runs successfully without errors
## Testing
Verified the fix works with multiple file patterns and confirmed no regressions in existing functionality.