### PR TITLE
Keep ts-morph project reference between watches

### DIFF
--- a/.changeset/wacky-llamas-rule.md
+++ b/.changeset/wacky-llamas-rule.md
@@ -1,0 +1,5 @@
+---
+'@eddeee888/gcg-typescript-resolver-files': patch
+---
+
+Keep ts-morph project reference between watches

--- a/packages/typescript-resolver-files/src/generateResolverFiles/getVariableStatementWithExpectedIdentifier.ts
+++ b/packages/typescript-resolver-files/src/generateResolverFiles/getVariableStatementWithExpectedIdentifier.ts
@@ -10,6 +10,7 @@ export const getVariableStatementWithExpectedIdentifier = (
 } => {
   let isExported = false;
 
+  sourceFile.refreshFromFileSystemSync();
   const variableStatementWithExpectedIdentifier =
     sourceFile.getVariableStatement((statement) => {
       let hasExpectedIdentifier = false;

--- a/packages/typescript-resolver-files/src/generateResolverFiles/getVariableStatementWithExpectedIdentifier.ts
+++ b/packages/typescript-resolver-files/src/generateResolverFiles/getVariableStatementWithExpectedIdentifier.ts
@@ -10,7 +10,6 @@ export const getVariableStatementWithExpectedIdentifier = (
 } => {
   let isExported = false;
 
-  sourceFile.refreshFromFileSystemSync();
   const variableStatementWithExpectedIdentifier =
     sourceFile.getVariableStatement((statement) => {
       let hasExpectedIdentifier = false;

--- a/packages/typescript-resolver-files/src/generateResolverFiles/postProcessFiles.ts
+++ b/packages/typescript-resolver-files/src/generateResolverFiles/postProcessFiles.ts
@@ -145,21 +145,21 @@ export const postProcessFiles = ({
         }
       );
     });
+
+    // 4. Apply to result files the updated content done in step 2. and 3. above
+    sourceFilesToProcess.forEach(({ sourceFile, resolverFile }) => {
+      const normalizedRelativePath = path.posix.relative(
+        cwd(),
+        sourceFile.getFilePath()
+      );
+
+      // Overwrite existing files with fixes
+      result.files[normalizedRelativePath] = {
+        ...resolverFile,
+        content: sourceFile.getText(),
+      };
+    });
   }
-
-  // 4. Apply to result files the updated content done in step 2. and 3. above
-  sourceFilesToProcess.forEach(({ sourceFile, resolverFile }) => {
-    const normalizedRelativePath = path.posix.relative(
-      cwd(),
-      sourceFile.getFilePath()
-    );
-
-    // Overwrite existing files with fixes
-    result.files[normalizedRelativePath] = {
-      ...resolverFile,
-      content: sourceFile.getText(),
-    };
-  });
 };
 
 /**

--- a/packages/typescript-resolver-files/src/preset.ts
+++ b/packages/typescript-resolver-files/src/preset.ts
@@ -29,6 +29,8 @@ import { logger } from './utils/index.js';
 
 export const presetName = '@eddeee888/gcg-typescript-resolver-files';
 
+let tsMorphProject: Project;
+
 export const preset: Types.OutputPreset<RawPresetConfig> = {
   buildGeneratesSection: async ({
     schema,
@@ -88,10 +90,12 @@ export const preset: Types.OutputPreset<RawPresetConfig> = {
       moduleNamingMode,
     });
 
-    const tsMorphProject = await profiler.run(
-      async () => new Project(tsMorphProjectOptions),
-      createProfilerRunName('Initialising ts-morph project')
-    );
+    if (!tsMorphProject) {
+      tsMorphProject = await profiler.run(
+        async () => new Project(tsMorphProjectOptions),
+        createProfilerRunName('Initialising ts-morph project')
+      );
+    }
 
     const typeMappersMap = await profiler.run(
       async () =>

--- a/packages/typescript-resolver-files/src/preset.ts
+++ b/packages/typescript-resolver-files/src/preset.ts
@@ -95,6 +95,12 @@ export const preset: Types.OutputPreset<RawPresetConfig> = {
         async () => new Project(tsMorphProjectOptions),
         createProfilerRunName('Initialising ts-morph project')
       );
+    } else {
+      await profiler.run(async () => {
+        tsMorphProject
+          .getSourceFiles()
+          .forEach((sourceFile) => sourceFile.refreshFromFileSystemSync());
+      }, createProfilerRunName('Refreshing ts-morph project files'));
     }
 
     const typeMappersMap = await profiler.run(


### PR DESCRIPTION
## Description

TODO

## Result

The main impact is on watch triggers, the part that typechecks and generates resolvers is 50% faster

### Before

4.11s (total 5.05s)
 
<img width="716" height="310" alt="Screenshot 2026-08-24 at 12 32 22 am" src="https://github.com/user-attachments/assets/10483e20-ff26-4ea4-89ed-7c460287b36f" />

### After

2.29s (total 3.35s)

<img width="716" height="310" alt="Screenshot 2026-08-24 at 12 30 01 am" src="https://github.com/user-attachments/assets/32d584a0-9daf-496d-a683-32c26cfe8a13" />
