### PR TITLE
Set `overwrite.removeStaleFiles=false` to improve watch behaviour

### DIFF
--- a/.changeset/pink-papers-sit.md
+++ b/.changeset/pink-papers-sit.md
@@ -1,0 +1,5 @@
+---
+'@eddeee888/gcg-typescript-resolver-files': patch
+---
+
+Set `overwrite.removeStaleFiles=false` (available in `@graphql-codegen/plugin-helpers` v7.2.0) to avoid scenario where resolver files are removed incorrectly.

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@graphql-codegen/add": "7.1.0",
     "@graphql-codegen/cli": "7.2.0",
     "@graphql-codegen/near-operation-file-preset": "5.2.1",
-    "@graphql-codegen/plugin-helpers": "7.1.0",
+    "@graphql-codegen/plugin-helpers": "7.2.0",
     "@graphql-codegen/schema-ast": "6.1.0",
     "@graphql-codegen/typescript": "6.1.0",
     "@graphql-codegen/typescript-react-apollo": "4.4.3-alpha-20260808101442-e439530add2acc6e119f54b148ccb537e4d0a7ec",

--- a/packages/typescript-resolver-files/package.json
+++ b/packages/typescript-resolver-files/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@eddeee888/gcg-server-config": "workspace:*",
     "@graphql-codegen/add": "^7.1.0",
-    "@graphql-codegen/plugin-helpers": "^7.1.0",
+    "@graphql-codegen/plugin-helpers": "^7.2.0",
     "@graphql-codegen/schema-ast": "^6.1.0",
     "@graphql-codegen/typescript": "^6.1.0",
     "@graphql-codegen/typescript-resolvers": "^6.1.0",

--- a/packages/typescript-resolver-files/src/defineConfig.spec.ts
+++ b/packages/typescript-resolver-files/src/defineConfig.spec.ts
@@ -9,6 +9,10 @@ describe('defineConfig()', () => {
       preset: defaultPreset,
       presetConfig: {},
       watchPattern: ['**/*.mappers.ts'],
+      overwrite: {
+        removeStaleFiles: false,
+        updateExistingFiles: true,
+      },
     });
   });
 
@@ -19,6 +23,10 @@ describe('defineConfig()', () => {
       preset: defaultPreset,
       presetConfig: {},
       watchPattern: ['src/schema/**/*.mappers.ts'],
+      overwrite: {
+        removeStaleFiles: false,
+        updateExistingFiles: true,
+      },
     });
   });
 
@@ -30,6 +38,10 @@ describe('defineConfig()', () => {
       presetConfig: {},
       watchPattern: ['**/*.mappers.ts'],
       schema: ['src/**/*.graphqls'],
+      overwrite: {
+        removeStaleFiles: false,
+        updateExistingFiles: true,
+      },
     });
   });
 
@@ -44,6 +56,10 @@ describe('defineConfig()', () => {
       presetConfig: {},
       watchPattern: ['**/*.mappers.ts'],
       hooks: { afterAllFileWrite: ['prettier --write'] },
+      overwrite: {
+        removeStaleFiles: false,
+        updateExistingFiles: true,
+      },
     });
   });
 

--- a/packages/typescript-resolver-files/src/defineConfig.ts
+++ b/packages/typescript-resolver-files/src/defineConfig.ts
@@ -12,7 +12,7 @@ export const defineConfig = (
   } = {}
 ): Pick<
   Types.ConfiguredOutput,
-  'preset' | 'presetConfig' | 'watchPattern' | 'schema' | 'hooks'
+  'preset' | 'presetConfig' | 'watchPattern' | 'schema' | 'hooks' | 'overwrite'
 > => {
   const { schema, baseOutputDir = '', hooks } = context;
 
@@ -33,5 +33,13 @@ export const defineConfig = (
     watchPattern,
     schema,
     hooks,
+    overwrite: {
+      // Server Preset needs to update existing resolver files
+      updateExistingFiles: true,
+      // When watching, it's common to avoid sending all files to Codegen to write to fs.
+      // When that happens, previously tracked files are marked as stale and gets removed wrongly.
+      // Therefore, we don't remove stale files.
+      removeStaleFiles: false,
+    },
   };
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -233,8 +233,8 @@ importers:
         specifier: 5.2.1
         version: 5.2.1(graphql@17.0.2)
       '@graphql-codegen/plugin-helpers':
-        specifier: 7.1.0
-        version: 7.1.0(graphql@17.0.2)
+        specifier: 7.2.0
+        version: 7.2.0(graphql@17.0.2)
       '@graphql-codegen/schema-ast':
         specifier: 6.1.0
         version: 6.1.0(graphql@17.0.2)
@@ -407,8 +407,8 @@ importers:
         specifier: ^7.1.0
         version: 7.1.0(graphql@17.0.2)
       '@graphql-codegen/plugin-helpers':
-        specifier: ^7.1.0
-        version: 7.1.0(graphql@17.0.2)
+        specifier: ^7.2.0
+        version: 7.2.0(graphql@17.0.2)
       '@graphql-codegen/schema-ast':
         specifier: ^6.1.0
         version: 6.1.0(graphql@17.0.2)
@@ -1465,6 +1465,12 @@ packages:
 
   '@graphql-codegen/plugin-helpers@7.1.0':
     resolution: {integrity: sha512-ieJH7kZ5oSZKBPJs7CvHMrFY/CLYLklqv74ir93qMwRna6geZsbIMoJzTDBXohxcQTITiProiYSGrEtZjIpYGg==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  '@graphql-codegen/plugin-helpers@7.2.0':
+    resolution: {integrity: sha512-RRr9iEokKYf30YCBihtPJvIla818ucsCrYiqzKSuY9GicCmhJxj/b6dYtgjFdEEILfRMdsrQhb/5bw6jiKBWlQ==}
     engines: {node: '>=16'}
     peerDependencies:
       graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
@@ -7669,6 +7675,15 @@ snapshots:
       tslib: 2.8.1
 
   '@graphql-codegen/plugin-helpers@7.1.0(graphql@17.0.2)':
+    dependencies:
+      '@graphql-tools/utils': 11.2.2(graphql@17.0.2)
+      change-case-all: 2.1.0
+      common-tags: 1.8.2
+      graphql: 17.0.2
+      import-from: 4.0.0
+      tslib: 2.8.1
+
+  '@graphql-codegen/plugin-helpers@7.2.0(graphql@17.0.2)':
     dependencies:
       '@graphql-tools/utils': 11.2.2(graphql@17.0.2)
       change-case-all: 2.1.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,3 +8,4 @@ allowBuilds:
   unrs-resolver: true
 minimumReleaseAgeExclude:
   - '@graphql-codegen/typescript-react-apollo@4.4.3-alpha-20260808101442-e439530add2acc6e119f54b148ccb537e4d0a7ec'
+  - '@graphql-codegen/plugin-helpers@7.2.0'


### PR DESCRIPTION
Set `overwrite.removeStaleFiles=false` (available in `@graphql-codegen/plugin-helpers` v7.2.0) to avoid scenario where resolver files are removed incorrectly.