### PR TITLE
Fix snapshot version detection in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,18 +129,18 @@ jobs:
             dir="${entry##*:}"  # part after the last ":"
             local_version=$(node -p "require('./$dir/package.json').version")
 
-            if [[ "$local_version" == 0.0.0-"$RELEASE_TAG"-* ]]; then
-              # Published in this run: `changeset version --snapshot` already wrote this
-              # exact version to package.json, so use it directly instead of asking the
-              # registry - `pnpm view`/npm's dist-tags read can lag a few seconds behind
-              # a publish and return the previous alpha version instead of the one we
-              # just published.
-              version="$local_version"
-            else
-              # Not touched by this PR's changesets, so nothing new was published for it
-              # this run - report whatever is currently tagged alpha.
-              version=$(pnpm view "$pkg" dist-tags.alpha)
+            if [[ "$local_version" != 0.0.0-"$RELEASE_TAG"-* ]]; then
+              # Not touched by this PR's changesets, so nothing was published for it
+              # this run - leave it out of the comment entirely.
+              continue
             fi
+
+            # Published in this run: `changeset version --snapshot` already wrote this
+            # exact version to package.json, so use it directly instead of asking the
+            # registry - `pnpm view`/npm's dist-tags read can lag a few seconds behind
+            # a publish and return the previous alpha version instead of the one we
+            # just published.
+            version="$local_version"
 
             echo "" >> $GITHUB_OUTPUT
             echo "$pkg@$version" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,20 +116,39 @@ jobs:
       - name: Get snapshot versions
         id: get_snapshot_versions
         run: |
+          # pkg name -> local package dir
           PACKAGES=(
-            "@eddeee888/gcg-operation-location-migration"
-            "@eddeee888/gcg-server-config"
-            "@eddeee888/gcg-typescript-resolver-files"
+            "@eddeee888/gcg-operation-location-migration:packages/operation-location-migration"
+            "@eddeee888/gcg-server-config:packages/server-config"
+            "@eddeee888/gcg-typescript-resolver-files:packages/typescript-resolver-files"
           )
 
           echo "versions<<EOF" >> $GITHUB_OUTPUT
-          for pkg in "${PACKAGES[@]}"; do
-            version=$(pnpm view "$pkg" dist-tags.alpha)
+          for entry in "${PACKAGES[@]}"; do
+            pkg="${entry%%:*}"
+            dir="${entry##*:}"
+            local_version=$(node -p "require('./$dir/package.json').version")
+
+            if [[ "$local_version" == 0.0.0-"$RELEASE_TAG"-* ]]; then
+              # Published in this run: `changeset version --snapshot` already wrote this
+              # exact version to package.json, so use it directly instead of asking the
+              # registry - `pnpm view`/npm's dist-tags read can lag a few seconds behind
+              # a publish and return the previous alpha version instead of the one we
+              # just published.
+              version="$local_version"
+            else
+              # Not touched by this PR's changesets, so nothing new was published for it
+              # this run - report whatever is currently tagged alpha.
+              version=$(pnpm view "$pkg" dist-tags.alpha)
+            fi
+
             echo "" >> $GITHUB_OUTPUT
             echo "$pkg@$version" >> $GITHUB_OUTPUT
           done
           echo "" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
+        env:
+          RELEASE_TAG: ${{ env.snapshot-release-tag }}
 
       - name: Report success
         if: success()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,8 +125,8 @@ jobs:
 
           echo "versions<<EOF" >> $GITHUB_OUTPUT
           for entry in "${PACKAGES[@]}"; do
-            pkg="${entry%%:*}"
-            dir="${entry##*:}"
+            pkg="${entry%%:*}"  # part before the first ":"
+            dir="${entry##*:}"  # part after the last ":"
             local_version=$(node -p "require('./$dir/package.json').version")
 
             if [[ "$local_version" == 0.0.0-"$RELEASE_TAG"-* ]]; then


### PR DESCRIPTION
## Summary
Updated the release workflow to reliably detect and report snapshot versions of packages published during the current `/release-snapshot` run, addressing a race condition where npm's dist-tags could return stale data — and to only report packages that were actually published this run.

## Key Changes
- Modified the snapshot version detection logic to read package versions directly from local `package.json` files instead of `pnpm view` dist-tags
- Added package-to-directory mapping in the `PACKAGES` array to enable local version lookups
- Implemented conditional logic that:
  - Uses the local version if it matches the current snapshot release tag pattern (indicating it was just published by this run)
  - Otherwise skips the package entirely — it's left out of the comment rather than reporting a stale registry version
- Added `RELEASE_TAG` environment variable to the step for version pattern matching
- Added inline comments explaining the `pkg`/`dir` string-splitting expansions

## Implementation Details
- The fix addresses a timing issue where `pnpm view`/npm's dist-tags can lag a few seconds behind a publish, potentially returning the previous alpha version instead of the newly published one
- By checking if the local version matches the expected snapshot pattern (`0.0.0-{RELEASE_TAG}-*`), we can confidently use it without waiting for registry propagation
- Packages not touched by the PR's changesets (so not published this run) are no longer listed in the comment at all — previously they showed a stale version from an unrelated prior run via the `pnpm view` fallback

https://claude.ai/code/session_01CauycheykQG78cB3zFfAYJ