### PR TITLE
Remove minimumReleaseAgeExclude for graphql-codegen packages

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,3 @@ allowBuilds:
   esbuild: true
   nx: true
   unrs-resolver: true
-minimumReleaseAgeExclude:
-  - '@graphql-codegen/cli'
-  - '@graphql-codegen/plugin-helpers'


### PR DESCRIPTION
## What

Removes the `minimumReleaseAgeExclude` entries for `@graphql-codegen/cli` and `@graphql-codegen/plugin-helpers` from `pnpm-workspace.yaml`.

## Why

These excludes were added when `package.json` was pinned to `@graphql-codegen/cli@7.4.0` and `@graphql-codegen/plugin-helpers@7.3.0` (published 2026-09-01), since both versions were too new for pnpm's `minimumReleaseAge` supply-chain check at the time.

The repo pins pnpm `11.7.0` via `devEngines.packageManager`, which defaults `minimumReleaseAge` to 1440 minutes (1 day) when unset. Both pinned versions are now several days old — well past that window — so the excludes are no longer needed.

## Verification

Activated the pinned pnpm version (`corepack prepare pnpm@11.7.0 --activate`) and ran a fresh `pnpm install --frozen-lockfile` with the excludes removed:

- Install completed cleanly (`✓ Lockfile passes supply-chain policies`).
- pnpm did not re-add the entries to `pnpm-workspace.yaml` (it auto-writes them back if a pinned version is still immature — it didn't here), confirming both packages now pass the age check on their own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DZKSusdmEZmakEQJJfRqQH

---
_Generated by [Claude Code](https://claude.ai/code/session_01DZKSusdmEZmakEQJJfRqQH)_